### PR TITLE
Update bouncing_block.osim geometry

### DIFF
--- a/Models/BouncingBlock/bouncing_block.osim
+++ b/Models/BouncingBlock/bouncing_block.osim
@@ -1,7 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<OpenSimDocument Version="30000">
+<OpenSimDocument Version="20303">
 	<Model name="toy_with_forces">
-		<credits>Author: Matt DeMers License: Creative Commons (CCBY 3.0). You are free to distribute, remix, tweak, and build upon this work, even commercially, as long as you credit us for the original creation. http://creativecommons.org/licenses/by/3.0/</credits>
+		<credits>
+      Author: Matt DeMers
+      License:
+      Creative Commons (CCBY 3.0). You are free to distribute, remix, tweak, and build upon this work, even commercially,
+      as long as you credit us for the original creation.
+      http://creativecommons.org/licenses/by/3.0/
+    </credits>
 		<publications>Unassigned</publications>
 		<length_units>m</length_units>
 		<force_units>N</force_units>
@@ -432,32 +438,20 @@
 		<ConstraintSet>
 			<objects>
 				<PointOnLineConstraint name="lock_block_to_y_axis">
-					<!--Flag indicating whether the constraint is disabled or not. Disabled means that the constraint is not active in subsequent dynamics realization-->
 					<isDisabled>false</isDisabled>
-					<!--Specify the body on which the line is defined-->
 					<line_body>ground</line_body>
-					<!--Direction of the line in line body specified in the line body frame.-->
-					<line_direction_vec>0 1 0</line_direction_vec>
-					<!--Specify the default point on the line in the line body frame.-->
-					<point_on_line>0 0 0</point_on_line>
-					<!--Specify the follower body constrained to the line.-->
+					<line_direction_vec> 0 1 0</line_direction_vec>
+					<point_on_line> 0 0 0</point_on_line>
 					<follower_body>block</follower_body>
-					<!--Specify the  point on the follower bocy constrained to the line in the follower body reference frame.-->
-					<point_on_follower>0 0 0</point_on_follower>
+					<point_on_follower> 0 0 0</point_on_follower>
 				</PointOnLineConstraint>
 				<PointOnLineConstraint name="lock_foot_to_y_axis">
-					<!--Flag indicating whether the constraint is disabled or not. Disabled means that the constraint is not active in subsequent dynamics realization-->
 					<isDisabled>false</isDisabled>
-					<!--Specify the body on which the line is defined-->
 					<line_body>ground</line_body>
-					<!--Direction of the line in line body specified in the line body frame.-->
-					<line_direction_vec>0 1 0</line_direction_vec>
-					<!--Specify the default point on the line in the line body frame.-->
-					<point_on_line>0 0 0</point_on_line>
-					<!--Specify the follower body constrained to the line.-->
+					<line_direction_vec> 0 1 0</line_direction_vec>
+					<point_on_line> 0 0 0</point_on_line>
 					<follower_body>link2</follower_body>
-					<!--Specify the  point on the follower bocy constrained to the line in the follower body reference frame.-->
-					<point_on_follower>0 0 0</point_on_follower>
+					<point_on_follower> 0 0 0</point_on_follower>
 				</PointOnLineConstraint>
 			</objects>
 			<groups />
@@ -497,7 +491,7 @@
 					<point1>0 0 0</point1>
 					<!--Force application point on body2.-->
 					<point2>0 0 0</point2>
-					<!--Spring stiffness (N/m).-->
+					<!--Spring stiffness.-->
 					<stiffness>2000</stiffness>
 					<!--Spring resting length.-->
 					<rest_length>0.8</rest_length>
@@ -535,13 +529,13 @@
 					<location_body_2>0 0.5 0</location_body_2>
 					<!--Orientation of bushing frame in body 2 as x-y-z, body fixed Euler rotations.-->
 					<orientation_body_2>0 0 0</orientation_body_2>
-					<!--Stiffness parameters resisting relative rotation (Nm/rad).-->
+					<!--Stiffness parameters resisting relative rotation.-->
 					<rotational_stiffness>10 10 10</rotational_stiffness>
-					<!--Stiffness parameters resisting relative translation (N/m).-->
+					<!--Stiffness parameters resisting relative translation.-->
 					<translational_stiffness>0 0 0</translational_stiffness>
-					<!--Damping parameters resisting relative angular velocity. (Nm/(rad/s))-->
+					<!--Damping parameters resisting relative angular velocity.-->
 					<rotational_damping>0.1 0.1 0.1</rotational_damping>
-					<!--Damping parameters resisting relative translational velocity. (N/(m/s)-->
+					<!--Damping parameters resisting relative translational velocity.-->
 					<translational_damping>0 0 0</translational_damping>
 				</BushingForce>
 			</objects>

--- a/Models/BouncingBlock/bouncing_block.osim
+++ b/Models/BouncingBlock/bouncing_block.osim
@@ -1,13 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<OpenSimDocument Version="20303">
+<OpenSimDocument Version="30000">
 	<Model name="toy_with_forces">
-		<credits>
-      Author: Matt DeMers
-      License:
-      Creative Commons (CCBY 3.0). You are free to distribute, remix, tweak, and build upon this work, even commercially,
-      as long as you credit us for the original creation.
-      http://creativecommons.org/licenses/by/3.0/
-    </credits>
+		<credits>Author: Matt DeMers License: Creative Commons (CCBY 3.0). You are free to distribute, remix, tweak, and build upon this work, even commercially, as long as you credit us for the original creation. http://creativecommons.org/licenses/by/3.0/</credits>
 		<publications>Unassigned</publications>
 		<length_units>m</length_units>
 		<force_units>N</force_units>
@@ -210,7 +204,7 @@
 							<objects>
 								<DisplayGeometry>
 									<!--Name of geometry file .vtp, .stl, .obj-->
-									<geometry_file>big_block_centered.vtp</geometry_file>
+									<geometry_file>block.vtp</geometry_file>
 									<!--Color used to display the geometry when visible-->
 									<color> 0.862745 0.117647 0.117647</color>
 									<!--Name of texture file .jpg, .bmp-->
@@ -218,7 +212,7 @@
 									<!--in body transform specified as 3 rotations (rad) followed by 3 translations rX rY rZ tx ty tz-->
 									<transform> -0 0 -0 0 0 0</transform>
 									<!--Three scale factors for display purposes: scaleX scaleY scaleZ-->
-									<scale_factors> 1 1 1</scale_factors>
+									<scale_factors> 2 2 2</scale_factors>
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
@@ -297,15 +291,31 @@
 							<objects>
 								<DisplayGeometry>
 									<!--Name of geometry file .vtp, .stl, .obj-->
-									<geometry_file>linkage1.vtp</geometry_file>
+									<geometry_file>block.vtp</geometry_file>
 									<!--Color used to display the geometry when visible-->
 									<color> 0.862745 0.117647 0.117647</color>
 									<!--Name of texture file .jpg, .bmp-->
 									<texture_file />
 									<!--in body transform specified as 3 rotations (rad) followed by 3 translations rX rY rZ tx ty tz-->
-									<transform> -0 0 -0 0 0 0</transform>
+									<transform> -0 0 -0 0 0.25 0</transform>
 									<!--Three scale factors for display purposes: scaleX scaleY scaleZ-->
-									<scale_factors> 1 1 1</scale_factors>
+									<scale_factors> 0.6 5 0.6</scale_factors>
+									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
+									<display_preference>4</display_preference>
+									<!--Display opacity between 0.0 and 1.0-->
+									<opacity>1</opacity>
+								</DisplayGeometry>
+								<DisplayGeometry>
+									<!--Name of geometry file .vtp, .stl, .obj-->
+									<geometry_file>sphere.vtp</geometry_file>
+									<!--Color used to display the geometry when visible-->
+									<color> 0.862745 0.117647 0.117647</color>
+									<!--Name of texture file .jpg, .bmp-->
+									<texture_file />
+									<!--in body transform specified as 3 rotations (rad) followed by 3 translations rX rY rZ tx ty tz-->
+									<transform> 0 0 0 0 0 0</transform>
+									<!--Three scale factors for display purposes: scaleX scaleY scaleZ-->
+									<scale_factors> 0.1 0.1 0.1</scale_factors>
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
@@ -384,15 +394,15 @@
 							<objects>
 								<DisplayGeometry>
 									<!--Name of geometry file .vtp, .stl, .obj-->
-									<geometry_file>linkage1.vtp</geometry_file>
+									<geometry_file>block.vtp</geometry_file>
 									<!--Color used to display the geometry when visible-->
 									<color> 0.862745 0.117647 0.117647</color>
 									<!--Name of texture file .jpg, .bmp-->
 									<texture_file />
 									<!--in body transform specified as 3 rotations (rad) followed by 3 translations rX rY rZ tx ty tz-->
-									<transform> -0 0 -0 0 0 0</transform>
+									<transform> 0 0 0 0 0.25 0</transform>
 									<!--Three scale factors for display purposes: scaleX scaleY scaleZ-->
-									<scale_factors> 1 1 1</scale_factors>
+									<scale_factors> 0.6 5 0.6</scale_factors>
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
@@ -422,20 +432,32 @@
 		<ConstraintSet>
 			<objects>
 				<PointOnLineConstraint name="lock_block_to_y_axis">
+					<!--Flag indicating whether the constraint is disabled or not. Disabled means that the constraint is not active in subsequent dynamics realization-->
 					<isDisabled>false</isDisabled>
+					<!--Specify the body on which the line is defined-->
 					<line_body>ground</line_body>
-					<line_direction_vec> 0 1 0</line_direction_vec>
-					<point_on_line> 0 0 0</point_on_line>
+					<!--Direction of the line in line body specified in the line body frame.-->
+					<line_direction_vec>0 1 0</line_direction_vec>
+					<!--Specify the default point on the line in the line body frame.-->
+					<point_on_line>0 0 0</point_on_line>
+					<!--Specify the follower body constrained to the line.-->
 					<follower_body>block</follower_body>
-					<point_on_follower> 0 0 0</point_on_follower>
+					<!--Specify the  point on the follower bocy constrained to the line in the follower body reference frame.-->
+					<point_on_follower>0 0 0</point_on_follower>
 				</PointOnLineConstraint>
 				<PointOnLineConstraint name="lock_foot_to_y_axis">
+					<!--Flag indicating whether the constraint is disabled or not. Disabled means that the constraint is not active in subsequent dynamics realization-->
 					<isDisabled>false</isDisabled>
+					<!--Specify the body on which the line is defined-->
 					<line_body>ground</line_body>
-					<line_direction_vec> 0 1 0</line_direction_vec>
-					<point_on_line> 0 0 0</point_on_line>
+					<!--Direction of the line in line body specified in the line body frame.-->
+					<line_direction_vec>0 1 0</line_direction_vec>
+					<!--Specify the default point on the line in the line body frame.-->
+					<point_on_line>0 0 0</point_on_line>
+					<!--Specify the follower body constrained to the line.-->
 					<follower_body>link2</follower_body>
-					<point_on_follower> 0 0 0</point_on_follower>
+					<!--Specify the  point on the follower bocy constrained to the line in the follower body reference frame.-->
+					<point_on_follower>0 0 0</point_on_follower>
 				</PointOnLineConstraint>
 			</objects>
 			<groups />
@@ -475,7 +497,7 @@
 					<point1>0 0 0</point1>
 					<!--Force application point on body2.-->
 					<point2>0 0 0</point2>
-					<!--Spring stiffness.-->
+					<!--Spring stiffness (N/m).-->
 					<stiffness>2000</stiffness>
 					<!--Spring resting length.-->
 					<rest_length>0.8</rest_length>
@@ -513,13 +535,13 @@
 					<location_body_2>0 0.5 0</location_body_2>
 					<!--Orientation of bushing frame in body 2 as x-y-z, body fixed Euler rotations.-->
 					<orientation_body_2>0 0 0</orientation_body_2>
-					<!--Stiffness parameters resisting relative rotation.-->
+					<!--Stiffness parameters resisting relative rotation (Nm/rad).-->
 					<rotational_stiffness>10 10 10</rotational_stiffness>
-					<!--Stiffness parameters resisting relative translation.-->
+					<!--Stiffness parameters resisting relative translation (N/m).-->
 					<translational_stiffness>0 0 0</translational_stiffness>
-					<!--Damping parameters resisting relative angular velocity.-->
+					<!--Damping parameters resisting relative angular velocity. (Nm/(rad/s))-->
 					<rotational_damping>0.1 0.1 0.1</rotational_damping>
-					<!--Damping parameters resisting relative translational velocity.-->
+					<!--Damping parameters resisting relative translational velocity. (N/(m/s)-->
 					<translational_damping>0 0 0</translational_damping>
 				</BushingForce>
 			</objects>

--- a/Models/BouncingBlock/bouncing_block_weak_spring.osim
+++ b/Models/BouncingBlock/bouncing_block_weak_spring.osim
@@ -204,7 +204,7 @@
 							<objects>
 								<DisplayGeometry>
 									<!--Name of geometry file .vtp, .stl, .obj-->
-									<geometry_file>big_block_centered.vtp</geometry_file>
+									<geometry_file>block.vtp</geometry_file>
 									<!--Color used to display the geometry when visible-->
 									<color> 0.862745 0.117647 0.117647</color>
 									<!--Name of texture file .jpg, .bmp-->
@@ -212,7 +212,7 @@
 									<!--in body transform specified as 3 rotations (rad) followed by 3 translations rX rY rZ tx ty tz-->
 									<transform> -0 0 -0 0 0 0</transform>
 									<!--Three scale factors for display purposes: scaleX scaleY scaleZ-->
-									<scale_factors> 1 1 1</scale_factors>
+									<scale_factors> 2 2 2</scale_factors>
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
@@ -291,15 +291,31 @@
 							<objects>
 								<DisplayGeometry>
 									<!--Name of geometry file .vtp, .stl, .obj-->
-									<geometry_file>linkage1.vtp</geometry_file>
+									<geometry_file>block.vtp</geometry_file>
 									<!--Color used to display the geometry when visible-->
 									<color> 0.862745 0.117647 0.117647</color>
 									<!--Name of texture file .jpg, .bmp-->
 									<texture_file />
 									<!--in body transform specified as 3 rotations (rad) followed by 3 translations rX rY rZ tx ty tz-->
-									<transform> -0 0 -0 0 0 0</transform>
+									<transform> -0 0 -0 0 0.25 0</transform>
 									<!--Three scale factors for display purposes: scaleX scaleY scaleZ-->
-									<scale_factors> 1 1 1</scale_factors>
+									<scale_factors> 0.6 5 0.6</scale_factors>
+									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
+									<display_preference>4</display_preference>
+									<!--Display opacity between 0.0 and 1.0-->
+									<opacity>1</opacity>
+								</DisplayGeometry>
+								<DisplayGeometry>
+									<!--Name of geometry file .vtp, .stl, .obj-->
+									<geometry_file>sphere.vtp</geometry_file>
+									<!--Color used to display the geometry when visible-->
+									<color> 0.862745 0.117647 0.117647</color>
+									<!--Name of texture file .jpg, .bmp-->
+									<texture_file />
+									<!--in body transform specified as 3 rotations (rad) followed by 3 translations rX rY rZ tx ty tz-->
+									<transform> 0 0 0 0 0 0</transform>
+									<!--Three scale factors for display purposes: scaleX scaleY scaleZ-->
+									<scale_factors> 0.1 0.1 0.1</scale_factors>
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
@@ -378,15 +394,15 @@
 							<objects>
 								<DisplayGeometry>
 									<!--Name of geometry file .vtp, .stl, .obj-->
-									<geometry_file>linkage1.vtp</geometry_file>
+									<geometry_file>block.vtp</geometry_file>
 									<!--Color used to display the geometry when visible-->
 									<color> 0.862745 0.117647 0.117647</color>
 									<!--Name of texture file .jpg, .bmp-->
 									<texture_file />
 									<!--in body transform specified as 3 rotations (rad) followed by 3 translations rX rY rZ tx ty tz-->
-									<transform> -0 0 -0 0 0 0</transform>
+									<transform> 0 0 0 0 0.25 0</transform>
 									<!--Three scale factors for display purposes: scaleX scaleY scaleZ-->
-									<scale_factors> 1 1 1</scale_factors>
+									<scale_factors> 0.6 5 0.6</scale_factors>
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->

--- a/Models/BouncingBlock/bouncing_block_weak_spring.osim
+++ b/Models/BouncingBlock/bouncing_block_weak_spring.osim
@@ -1,13 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<OpenSimDocument Version="20303">
+<OpenSimDocument Version="30000">
 	<Model name="toy_with_forces">
-		<credits>
-      Author: Matt DeMers
-      License:
-      Creative Commons (CCBY 3.0). You are free to distribute, remix, tweak, and build upon this work, even commercially,
-      as long as you credit us for the original creation.
-      http://creativecommons.org/licenses/by/3.0/
-    </credits>
+		<credits>Author: Matt DeMers License: Creative Commons (CCBY 3.0). You are free to distribute, remix, tweak, and build upon this work, even commercially, as long as you credit us for the original creation. http://creativecommons.org/licenses/by/3.0/</credits>
 		<publications>Unassigned</publications>
 		<length_units>m</length_units>
 		<force_units>N</force_units>
@@ -422,20 +416,32 @@
 		<ConstraintSet>
 			<objects>
 				<PointOnLineConstraint name="lock_block_to_y_axis">
+					<!--Flag indicating whether the constraint is disabled or not. Disabled means that the constraint is not active in subsequent dynamics realization-->
 					<isDisabled>false</isDisabled>
+					<!--Specify the body on which the line is defined-->
 					<line_body>ground</line_body>
-					<line_direction_vec> 0 1 0</line_direction_vec>
-					<point_on_line> 0 0 0</point_on_line>
+					<!--Direction of the line in line body specified in the line body frame.-->
+					<line_direction_vec>0 1 0</line_direction_vec>
+					<!--Specify the default point on the line in the line body frame.-->
+					<point_on_line>0 0 0</point_on_line>
+					<!--Specify the follower body constrained to the line.-->
 					<follower_body>block</follower_body>
-					<point_on_follower> 0 0 0</point_on_follower>
+					<!--Specify the  point on the follower bocy constrained to the line in the follower body reference frame.-->
+					<point_on_follower>0 0 0</point_on_follower>
 				</PointOnLineConstraint>
 				<PointOnLineConstraint name="lock_foot_to_y_axis">
+					<!--Flag indicating whether the constraint is disabled or not. Disabled means that the constraint is not active in subsequent dynamics realization-->
 					<isDisabled>false</isDisabled>
+					<!--Specify the body on which the line is defined-->
 					<line_body>ground</line_body>
-					<line_direction_vec> 0 1 0</line_direction_vec>
-					<point_on_line> 0 0 0</point_on_line>
+					<!--Direction of the line in line body specified in the line body frame.-->
+					<line_direction_vec>0 1 0</line_direction_vec>
+					<!--Specify the default point on the line in the line body frame.-->
+					<point_on_line>0 0 0</point_on_line>
+					<!--Specify the follower body constrained to the line.-->
 					<follower_body>link2</follower_body>
-					<point_on_follower> 0 0 0</point_on_follower>
+					<!--Specify the  point on the follower bocy constrained to the line in the follower body reference frame.-->
+					<point_on_follower>0 0 0</point_on_follower>
 				</PointOnLineConstraint>
 			</objects>
 			<groups />
@@ -475,7 +481,7 @@
 					<point1>0 0 0</point1>
 					<!--Force application point on body2.-->
 					<point2>0 0 0</point2>
-					<!--Spring stiffness.-->
+					<!--Spring stiffness (N/m).-->
 					<stiffness>20</stiffness>
 					<!--Spring resting length.-->
 					<rest_length>0.8</rest_length>
@@ -513,13 +519,13 @@
 					<location_body_2>0 0.5 0</location_body_2>
 					<!--Orientation of bushing frame in body 2 as x-y-z, body fixed Euler rotations.-->
 					<orientation_body_2>0 0 0</orientation_body_2>
-					<!--Stiffness parameters resisting relative rotation.-->
+					<!--Stiffness parameters resisting relative rotation (Nm/rad).-->
 					<rotational_stiffness>10 10 10</rotational_stiffness>
-					<!--Stiffness parameters resisting relative translation.-->
+					<!--Stiffness parameters resisting relative translation (N/m).-->
 					<translational_stiffness>0 0 0</translational_stiffness>
-					<!--Damping parameters resisting relative angular velocity.-->
+					<!--Damping parameters resisting relative angular velocity. (Nm/(rad/s))-->
 					<rotational_damping>0.1 0.1 0.1</rotational_damping>
-					<!--Damping parameters resisting relative translational velocity.-->
+					<!--Damping parameters resisting relative translational velocity. (N/(m/s)-->
 					<translational_damping>0 0 0</translational_damping>
 				</BushingForce>
 			</objects>

--- a/Models/BouncingBlock/bouncing_block_weak_spring.osim
+++ b/Models/BouncingBlock/bouncing_block_weak_spring.osim
@@ -1,7 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<OpenSimDocument Version="30000">
+<OpenSimDocument Version="20303">
 	<Model name="toy_with_forces">
-		<credits>Author: Matt DeMers License: Creative Commons (CCBY 3.0). You are free to distribute, remix, tweak, and build upon this work, even commercially, as long as you credit us for the original creation. http://creativecommons.org/licenses/by/3.0/</credits>
+		<credits>
+      Author: Matt DeMers
+      License:
+      Creative Commons (CCBY 3.0). You are free to distribute, remix, tweak, and build upon this work, even commercially,
+      as long as you credit us for the original creation.
+      http://creativecommons.org/licenses/by/3.0/
+    </credits>
 		<publications>Unassigned</publications>
 		<length_units>m</length_units>
 		<force_units>N</force_units>
@@ -297,7 +303,7 @@
 									<!--Name of texture file .jpg, .bmp-->
 									<texture_file />
 									<!--in body transform specified as 3 rotations (rad) followed by 3 translations rX rY rZ tx ty tz-->
-									<transform> -0 0 -0 0 0.25 0</transform>
+									<transform> 0 0 0 0 0.25 0</transform>
 									<!--Three scale factors for display purposes: scaleX scaleY scaleZ-->
 									<scale_factors> 0.6 5 0.6</scale_factors>
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
@@ -432,32 +438,20 @@
 		<ConstraintSet>
 			<objects>
 				<PointOnLineConstraint name="lock_block_to_y_axis">
-					<!--Flag indicating whether the constraint is disabled or not. Disabled means that the constraint is not active in subsequent dynamics realization-->
 					<isDisabled>false</isDisabled>
-					<!--Specify the body on which the line is defined-->
 					<line_body>ground</line_body>
-					<!--Direction of the line in line body specified in the line body frame.-->
-					<line_direction_vec>0 1 0</line_direction_vec>
-					<!--Specify the default point on the line in the line body frame.-->
-					<point_on_line>0 0 0</point_on_line>
-					<!--Specify the follower body constrained to the line.-->
+					<line_direction_vec> 0 1 0</line_direction_vec>
+					<point_on_line> 0 0 0</point_on_line>
 					<follower_body>block</follower_body>
-					<!--Specify the  point on the follower bocy constrained to the line in the follower body reference frame.-->
-					<point_on_follower>0 0 0</point_on_follower>
+					<point_on_follower> 0 0 0</point_on_follower>
 				</PointOnLineConstraint>
 				<PointOnLineConstraint name="lock_foot_to_y_axis">
-					<!--Flag indicating whether the constraint is disabled or not. Disabled means that the constraint is not active in subsequent dynamics realization-->
 					<isDisabled>false</isDisabled>
-					<!--Specify the body on which the line is defined-->
 					<line_body>ground</line_body>
-					<!--Direction of the line in line body specified in the line body frame.-->
-					<line_direction_vec>0 1 0</line_direction_vec>
-					<!--Specify the default point on the line in the line body frame.-->
-					<point_on_line>0 0 0</point_on_line>
-					<!--Specify the follower body constrained to the line.-->
+					<line_direction_vec> 0 1 0</line_direction_vec>
+					<point_on_line> 0 0 0</point_on_line>
 					<follower_body>link2</follower_body>
-					<!--Specify the  point on the follower bocy constrained to the line in the follower body reference frame.-->
-					<point_on_follower>0 0 0</point_on_follower>
+					<point_on_follower> 0 0 0</point_on_follower>
 				</PointOnLineConstraint>
 			</objects>
 			<groups />
@@ -497,7 +491,7 @@
 					<point1>0 0 0</point1>
 					<!--Force application point on body2.-->
 					<point2>0 0 0</point2>
-					<!--Spring stiffness (N/m).-->
+					<!--Spring stiffness.-->
 					<stiffness>20</stiffness>
 					<!--Spring resting length.-->
 					<rest_length>0.8</rest_length>
@@ -535,13 +529,13 @@
 					<location_body_2>0 0.5 0</location_body_2>
 					<!--Orientation of bushing frame in body 2 as x-y-z, body fixed Euler rotations.-->
 					<orientation_body_2>0 0 0</orientation_body_2>
-					<!--Stiffness parameters resisting relative rotation (Nm/rad).-->
+					<!--Stiffness parameters resisting relative rotation.-->
 					<rotational_stiffness>10 10 10</rotational_stiffness>
-					<!--Stiffness parameters resisting relative translation (N/m).-->
+					<!--Stiffness parameters resisting relative translation.-->
 					<translational_stiffness>0 0 0</translational_stiffness>
-					<!--Damping parameters resisting relative angular velocity. (Nm/(rad/s))-->
+					<!--Damping parameters resisting relative angular velocity.-->
 					<rotational_damping>0.1 0.1 0.1</rotational_damping>
-					<!--Damping parameters resisting relative translational velocity. (N/(m/s)-->
+					<!--Damping parameters resisting relative translational velocity.-->
 					<translational_damping>0 0 0</translational_damping>
 				</BushingForce>
 			</objects>


### PR DESCRIPTION
The original custom made geometry (.vtp) files: *big_block_centered.vtp* and *linkage1.vtp* are binary formats that are not currently supported in 4.0. Rather than convert these to be ascii, I replaced them with already available *block* and *sphere* .vtp files that are available in 3.3 and 4.0. 

This update was required for a fix to the related API issue [API 1762](https://github.com/opensim-org/opensim-core/issues/1762) and subsequent [PR 1902](https://github.com/opensim-org/opensim-core/pull/1902).

I am able to load these models in both 3.3 and 4.0 without issues.