### PR TITLE
Exhume subterranean models

### DIFF
--- a/Models/Gait10dof18musc/gait10dof18musc.osim
+++ b/Models/Gait10dof18musc/gait10dof18musc.osim
@@ -106,7 +106,7 @@
 										<!--Coordinate can describe rotational, translational, or coupled motion. Defaults to rotational.-->
 										<motion_type>translational</motion_type>
 										<!--The value of this coordinate before any value has been set. Rotational coordinate value is in radians and Translational in meters.-->
-										<default_value>0</default_value>
+										<default_value>0.95</default_value>
 										<!--The speed value of this coordinate before any value has been set. Rotational coordinate value is in rad/s and Translational in m/s.-->
 										<default_speed_value>0</default_speed_value>
 										<!--The minimum and maximum values that the coordinate can range between. Rotational coordinate range in radians and Translational in meters.-->

--- a/Models/Gait10dof18musc/subject01.osim
+++ b/Models/Gait10dof18musc/subject01.osim
@@ -106,7 +106,7 @@
 										<!--Coordinate can describe rotational, translational, or coupled motion. Defaults to rotational.-->
 										<motion_type>translational</motion_type>
 										<!--The value of this coordinate before any value has been set. Rotational coordinate value is in radians and Translational in meters.-->
-										<default_value>0</default_value>
+										<default_value>1.015</default_value>
 										<!--The speed value of this coordinate before any value has been set. Rotational coordinate value is in rad/s and Translational in m/s.-->
 										<default_speed_value>0</default_speed_value>
 										<!--The minimum and maximum values that the coordinate can range between. Rotational coordinate range in radians and Translational in meters.-->

--- a/Models/Gait10dof18musc/subject01_metabolics.osim
+++ b/Models/Gait10dof18musc/subject01_metabolics.osim
@@ -106,7 +106,7 @@
 										<!--Coordinate can describe rotational, translational, or coupled motion. Defaults to rotational.-->
 										<motion_type>translational</motion_type>
 										<!--The value of this coordinate before any value has been set. Rotational coordinate value is in radians and Translational in meters.-->
-										<default_value>0</default_value>
+										<default_value>1.015</default_value>
 										<!--The speed value of this coordinate before any value has been set. Rotational coordinate value is in rad/s and Translational in m/s.-->
 										<default_speed_value>0</default_speed_value>
 										<!--The minimum and maximum values that the coordinate can range between. Rotational coordinate range in radians and Translational in meters.-->

--- a/Models/Gait10dof18musc/subject01_metabolics_path_actuator.osim
+++ b/Models/Gait10dof18musc/subject01_metabolics_path_actuator.osim
@@ -106,7 +106,7 @@
 										<!--Coordinate can describe rotational, translational, or coupled motion. Defaults to rotational.-->
 										<motion_type>translational</motion_type>
 										<!--The value of this coordinate before any value has been set. Rotational coordinate value is in radians and Translational in meters.-->
-										<default_value>0</default_value>
+										<default_value>1.015</default_value>
 										<!--The speed value of this coordinate before any value has been set. Rotational coordinate value is in rad/s and Translational in m/s.-->
 										<default_speed_value>0</default_speed_value>
 										<!--The minimum and maximum values that the coordinate can range between. Rotational coordinate range in radians and Translational in meters.-->

--- a/Models/Gait10dof18musc/subject01_metabolics_path_spring.osim
+++ b/Models/Gait10dof18musc/subject01_metabolics_path_spring.osim
@@ -106,7 +106,7 @@
 										<!--Coordinate can describe rotational, translational, or coupled motion. Defaults to rotational.-->
 										<motion_type>translational</motion_type>
 										<!--The value of this coordinate before any value has been set. Rotational coordinate value is in radians and Translational in meters.-->
-										<default_value>0</default_value>
+										<default_value>1.015</default_value>
 										<!--The speed value of this coordinate before any value has been set. Rotational coordinate value is in rad/s and Translational in m/s.-->
 										<default_speed_value>0</default_speed_value>
 										<!--The minimum and maximum values that the coordinate can range between. Rotational coordinate range in radians and Translational in meters.-->

--- a/Models/Gait10dof18musc/subject01_metabolics_spring.osim
+++ b/Models/Gait10dof18musc/subject01_metabolics_spring.osim
@@ -106,7 +106,7 @@
 										<!--Coordinate can describe rotational, translational, or coupled motion. Defaults to rotational.-->
 										<motion_type>translational</motion_type>
 										<!--The value of this coordinate before any value has been set. Rotational coordinate value is in radians and Translational in meters.-->
-										<default_value>0</default_value>
+										<default_value>1.015</default_value>
 										<!--The speed value of this coordinate before any value has been set. Rotational coordinate value is in rad/s and Translational in m/s.-->
 										<default_speed_value>0</default_speed_value>
 										<!--The minimum and maximum values that the coordinate can range between. Rotational coordinate range in radians and Translational in meters.-->

--- a/Models/Gait2354_Simbody/gait2354_simbody.osim
+++ b/Models/Gait2354_Simbody/gait2354_simbody.osim
@@ -164,7 +164,7 @@
 										<!--Coordinate can describe rotational, translational, or coupled motion. Defaults to rotational.-->
 										<motion_type>translational</motion_type>
 										<!--The value of this coordinate before any value has been set. Rotational coordinate value is in radians and Translational in meters.-->
-										<default_value>0</default_value>
+										<default_value>0.95</default_value>
 										<!--The speed value of this coordinate before any value has been set. Rotational coordinate value is in rad/s and Translational in m/s.-->
 										<default_speed_value>0</default_speed_value>
 										<!--The minimum and maximum values that the coordinate can range between. Rotational coordinate range in radians and Translational in meters.-->

--- a/Models/Gait2354_Simbody/subject01_simbody.osim
+++ b/Models/Gait2354_Simbody/subject01_simbody.osim
@@ -229,7 +229,7 @@
 										<!--Coordinate can describe rotational, translational, or coupled motion. Defaults to rotational.-->
 										<motion_type>translational</motion_type>
 										<!--The value of this coordinate before any value has been set. Rotational coordinate value is in radians and Translational in meters.-->
-										<default_value>0</default_value>
+										<default_value>1.015</default_value>
 										<!--The speed value of this coordinate before any value has been set. Rotational coordinate value is in rad/s and Translational in m/s.-->
 										<default_speed_value>0</default_speed_value>
 										<!--The minimum and maximum values that the coordinate can range between. Rotational coordinate range in radians and Translational in meters.-->

--- a/Models/Gait2392_Simbody/gait2392_millard2012muscle.osim
+++ b/Models/Gait2392_Simbody/gait2392_millard2012muscle.osim
@@ -244,7 +244,7 @@
 										<!--Coordinate can describe rotational, translational, or coupled motion. Defaults to rotational.-->
 										<motion_type>translational</motion_type>
 										<!--The value of this coordinate before any value has been set. Rotational coordinate value is in radians and Translational in meters.-->
-										<default_value>0</default_value>
+										<default_value>0.95</default_value>
 										<!--The speed value of this coordinate before any value has been set. Rotational coordinate value is in rad/s and Translational in m/s.-->
 										<default_speed_value>0</default_speed_value>
 										<!--The minimum and maximum values that the coordinate can range between. Rotational coordinate range in radians and Translational in meters.-->

--- a/Models/Gait2392_Simbody/gait2392_thelen2003muscle.osim
+++ b/Models/Gait2392_Simbody/gait2392_thelen2003muscle.osim
@@ -244,7 +244,7 @@
 										<!--Coordinate can describe rotational, translational, or coupled motion. Defaults to rotational.-->
 										<motion_type>translational</motion_type>
 										<!--The value of this coordinate before any value has been set. Rotational coordinate value is in radians and Translational in meters.-->
-										<default_value>0</default_value>
+										<default_value>0.95</default_value>
 										<!--The speed value of this coordinate before any value has been set. Rotational coordinate value is in rad/s and Translational in m/s.-->
 										<default_speed_value>0</default_speed_value>
 										<!--The minimum and maximum values that the coordinate can range between. Rotational coordinate range in radians and Translational in meters.-->

--- a/Models/Gait2392_Simbody/subject01.osim
+++ b/Models/Gait2392_Simbody/subject01.osim
@@ -159,7 +159,7 @@
 										<!--Coordinate can describe rotational, translational, or coupled motion. Defaults to rotational.-->
 										<motion_type>translational</motion_type>
 										<!--The value of this coordinate before any value has been set. Rotational coordinate value is in radians and Translational in meters.-->
-										<default_value>0</default_value>
+										<default_value>1.015</default_value>
 										<!--The speed value of this coordinate before any value has been set. Rotational coordinate value is in rad/s and Translational in m/s.-->
 										<default_speed_value>0</default_speed_value>
 										<!--The minimum and maximum values that the coordinate can range between. Rotational coordinate range in radians and Translational in meters.-->

--- a/Models/Gait2392_Simbody/subject01_adjusted.osim
+++ b/Models/Gait2392_Simbody/subject01_adjusted.osim
@@ -159,7 +159,7 @@
 										<!--Coordinate can describe rotational, translational, or coupled motion. Defaults to rotational.-->
 										<motion_type>translational</motion_type>
 										<!--The value of this coordinate before any value has been set. Rotational coordinate value is in radians and Translational in meters.-->
-										<default_value>0</default_value>
+										<default_value>1.015</default_value>
 										<!--The speed value of this coordinate before any value has been set. Rotational coordinate value is in rad/s and Translational in m/s.-->
 										<default_speed_value>0</default_speed_value>
 										<!--The minimum and maximum values that the coordinate can range between. Rotational coordinate range in radians and Translational in meters.-->

--- a/Models/Gait2392_Simbody/subject01_simbody_adjusted.osim
+++ b/Models/Gait2392_Simbody/subject01_simbody_adjusted.osim
@@ -245,7 +245,7 @@
 										<!--Coordinate can describe rotational, translational, or coupled motion. Defaults to rotational.-->
 										<motion_type>translational</motion_type>
 										<!--The value of this coordinate before any value has been set. Rotational coordinate value is in radians and Translational in meters.-->
-										<default_value>0</default_value>
+										<default_value>1.015</default_value>
 										<!--The speed value of this coordinate before any value has been set. Rotational coordinate value is in rad/s and Translational in m/s.-->
 										<default_speed_value>0</default_speed_value>
 										<!--The minimum and maximum values that the coordinate can range between. Rotational coordinate range in radians and Translational in meters.-->

--- a/Models/Pendulum/double_pendulum.osim
+++ b/Models/Pendulum/double_pendulum.osim
@@ -76,7 +76,7 @@
 							<!--Name of the parent body to which this joint connects its owner body.-->
 							<parent_body>ground</parent_body>
 							<!--Location of the joint in the parent body specified in the parent reference frame. Default is (0,0,0).-->
-							<location_in_parent>0 0 0</location_in_parent>
+							<location_in_parent>0 1 0</location_in_parent>
 							<!--Orientation of the joint in the parent body specified in the parent reference frame. Euler XYZ body-fixed rotation angles are used to express the orientation. Default is (0,0,0).-->
 							<orientation_in_parent>0 0 0</orientation_in_parent>
 							<!--Location of the joint in the child body specified in the child reference frame. For SIMM models, this vector is always the zero vector (i.e., the body reference frame coincides with the joint). -->


### PR DESCRIPTION
Redo of #39 (see explanation there for opening a fresh PR).

#39 adjusted 6 models:
- gait2354_simbody.osim
- gait2354_with_pat_lig.osim
- gait2392_millard2012muscle.osim
- gait2392_thelen2003muscle.osim
- double_pendulum.osim
- wrist.osim

I was unable to reverse-engineer the logic for determining which models were to be exhumed, so I dug up the following:
- 6 models in Gait10dof18musc directory
- 2 models in Gait2354_Simbody directory (not gait2354_with_pat_lig.osim as it looks like that model is already above ground—though I was unable to confirm in 4.0)
- 5 models in Gait2392_Simbody directory
- double_pendulum.osim in Pendulum directory

The wrist model is already above ground on master and does not require modification.

The various gait models appear to come in two heights, hence some are moved to 0.95 and others to 1.015. To avoid updating the file version (and, consequently, changing thousands of lines), I modified the model in the 4.0 GUI, closed the model without saving, changed the corresponding property in Notepad++, then opened again in the GUI to confirm.