### PR TITLE
Repair ToyLandingModel

### DIFF
--- a/Models/ToyLanding/ToyLandingModel.osim
+++ b/Models/ToyLanding/ToyLandingModel.osim
@@ -8228,7 +8228,7 @@
 						<objects>
 							<HuntCrossleyForce::ContactParameters>
 								<!--Names of geometry objects affected by these parameters.-->
-								<geometry>platform heel_r ball_big_toe_r small_toe_r</geometry>
+								<geometry>platformSurface heel_r ball_big_toe_r small_toe_r</geometry>
 								<stiffness>100000000</stiffness>
 								<dissipation>0.5</dissipation>
 								<static_friction>0.9</static_friction>
@@ -8249,7 +8249,7 @@
 						<objects>
 							<HuntCrossleyForce::ContactParameters>
 								<!--Names of geometry objects affected by these parameters.-->
-								<geometry>platform heel_l ball_big_toe_l small_toe_l</geometry>
+								<geometry>platformSurface heel_l ball_big_toe_l small_toe_l</geometry>
 								<stiffness>100000000</stiffness>
 								<dissipation>0.5</dissipation>
 								<static_friction>0.9</static_friction>
@@ -8502,7 +8502,7 @@
 		<!--ContactGeometries  in the model.-->
 		<ContactGeometrySet>
 			<objects>
-				<ContactHalfSpace name="platform">
+				<ContactHalfSpace name="platformSurface">
 					<!--Body name to connect the contact geometry to-->
 					<body_name>platform</body_name>
 					<!--Location of geometry center in the body frame-->

--- a/Models/ToyLanding/ToyLandingModel.osim
+++ b/Models/ToyLanding/ToyLandingModel.osim
@@ -8592,7 +8592,7 @@
 					<!--Factor by which the stretch reflex is scaled.-->
 					<gain>0.85</gain>
 				</ToyReflexController>
-				<PrescribedController name="R-inverter controls">
+				<PrescribedController name="R-inverter-controls">
 					<!--Flag (true or false) indicating whether or not the controller is disabled.-->
 					<isDisabled>true</isDisabled>
 					<!--The list of model actuators that this controller will control.The keyword ALL indicates the controller will controll all the acuators in the model-->
@@ -8619,7 +8619,7 @@
 						<groups />
 					</FunctionSet>
 				</PrescribedController>
-				<PrescribedController name="R-everter controls">
+				<PrescribedController name="R-everter-controls">
 					<!--Flag (true or false) indicating whether or not the controller is disabled.-->
 					<isDisabled>true</isDisabled>
 					<!--The list of model actuators that this controller will control.The keyword ALL indicates the controller will controll all the acuators in the model-->

--- a/Models/ToyLanding/ToyLandingModel.osim
+++ b/Models/ToyLanding/ToyLandingModel.osim
@@ -8228,7 +8228,7 @@
 						<objects>
 							<HuntCrossleyForce::ContactParameters>
 								<!--Names of geometry objects affected by these parameters.-->
-								<geometry>platformSurface heel_r ball_big_toe_r small_toe_r</geometry>
+								<geometry>platform_surface heel_r ball_big_toe_r small_toe_r</geometry>
 								<stiffness>100000000</stiffness>
 								<dissipation>0.5</dissipation>
 								<static_friction>0.9</static_friction>
@@ -8249,7 +8249,7 @@
 						<objects>
 							<HuntCrossleyForce::ContactParameters>
 								<!--Names of geometry objects affected by these parameters.-->
-								<geometry>platformSurface heel_l ball_big_toe_l small_toe_l</geometry>
+								<geometry>platform_surface heel_l ball_big_toe_l small_toe_l</geometry>
 								<stiffness>100000000</stiffness>
 								<dissipation>0.5</dissipation>
 								<static_friction>0.9</static_friction>
@@ -8502,7 +8502,7 @@
 		<!--ContactGeometries  in the model.-->
 		<ContactGeometrySet>
 			<objects>
-				<ContactHalfSpace name="platformSurface">
+				<ContactHalfSpace name="platform_surface">
 					<!--Body name to connect the contact geometry to-->
 					<body_name>platform</body_name>
 					<!--Location of geometry center in the body frame-->

--- a/Models/ToyLanding/ToyLandingModel_AFO.osim
+++ b/Models/ToyLanding/ToyLandingModel_AFO.osim
@@ -8412,7 +8412,7 @@
 						<objects>
 							<HuntCrossleyForce::ContactParameters>
 								<!--Names of geometry objects affected by these parameters.-->
-								<geometry>platformSurface heel_r ball_big_toe_r small_toe_r</geometry>
+								<geometry>platform_surface heel_r ball_big_toe_r small_toe_r</geometry>
 								<stiffness>100000000</stiffness>
 								<dissipation>0.5</dissipation>
 								<static_friction>0.9</static_friction>
@@ -8433,7 +8433,7 @@
 						<objects>
 							<HuntCrossleyForce::ContactParameters>
 								<!--Names of geometry objects affected by these parameters.-->
-								<geometry>platformSurface heel_l ball_big_toe_l small_toe_l</geometry>
+								<geometry>platform_surface heel_l ball_big_toe_l small_toe_l</geometry>
 								<stiffness>100000000</stiffness>
 								<dissipation>0.5</dissipation>
 								<static_friction>0.9</static_friction>
@@ -8686,7 +8686,7 @@
 		<!--ContactGeometries  in the model.-->
 		<ContactGeometrySet>
 			<objects>
-				<ContactHalfSpace name="platformSurface">
+				<ContactHalfSpace name="platform_surface">
 					<!--Body name to connect the contact geometry to-->
 					<body_name>platform</body_name>
 					<!--Location of geometry center in the body frame-->

--- a/Models/ToyLanding/ToyLandingModel_AFO.osim
+++ b/Models/ToyLanding/ToyLandingModel_AFO.osim
@@ -8412,7 +8412,7 @@
 						<objects>
 							<HuntCrossleyForce::ContactParameters>
 								<!--Names of geometry objects affected by these parameters.-->
-								<geometry>platform heel_r ball_big_toe_r small_toe_r</geometry>
+								<geometry>platformSurface heel_r ball_big_toe_r small_toe_r</geometry>
 								<stiffness>100000000</stiffness>
 								<dissipation>0.5</dissipation>
 								<static_friction>0.9</static_friction>
@@ -8433,7 +8433,7 @@
 						<objects>
 							<HuntCrossleyForce::ContactParameters>
 								<!--Names of geometry objects affected by these parameters.-->
-								<geometry>platform heel_l ball_big_toe_l small_toe_l</geometry>
+								<geometry>platformSurface heel_l ball_big_toe_l small_toe_l</geometry>
 								<stiffness>100000000</stiffness>
 								<dissipation>0.5</dissipation>
 								<static_friction>0.9</static_friction>
@@ -8686,7 +8686,7 @@
 		<!--ContactGeometries  in the model.-->
 		<ContactGeometrySet>
 			<objects>
-				<ContactHalfSpace name="platform">
+				<ContactHalfSpace name="platformSurface">
 					<!--Body name to connect the contact geometry to-->
 					<body_name>platform</body_name>
 					<!--Location of geometry center in the body frame-->

--- a/Models/ToyLanding/ToyLandingModel_AFO.osim
+++ b/Models/ToyLanding/ToyLandingModel_AFO.osim
@@ -8776,7 +8776,7 @@
 					<!--Factor by which the stretch reflex is scaled.-->
 					<gain>0.85</gain>
 				</ToyReflexController>
-				<PrescribedController name="R-inverter controls">
+				<PrescribedController name="R-inverter-controls">
 					<!--Flag (true or false) indicating whether or not the controller is disabled.-->
 					<isDisabled>true</isDisabled>
 					<!--The list of model actuators that this controller will control.The keyword ALL indicates the controller will controll all the acuators in the model-->
@@ -8803,7 +8803,7 @@
 						<groups />
 					</FunctionSet>
 				</PrescribedController>
-				<PrescribedController name="R-everter controls">
+				<PrescribedController name="R-everter-controls">
 					<!--Flag (true or false) indicating whether or not the controller is disabled.-->
 					<isDisabled>true</isDisabled>
 					<!--The list of model actuators that this controller will control.The keyword ALL indicates the controller will controll all the acuators in the model-->

--- a/Models/ToyLanding/ToyLandingModel_activeAFO.osim
+++ b/Models/ToyLanding/ToyLandingModel_activeAFO.osim
@@ -8780,7 +8780,7 @@
 					<!--Factor by which the stretch reflex is scaled.-->
 					<gain>0.85</gain>
 				</ToyReflexController>
-				<PrescribedController name="R-inverter controls">
+				<PrescribedController name="R-inverter-controls">
 					<!--Flag (true or false) indicating whether or not the controller is disabled.-->
 					<isDisabled>true</isDisabled>
 					<!--The list of model actuators that this controller will control.The keyword ALL indicates the controller will controll all the acuators in the model-->
@@ -8807,7 +8807,7 @@
 						<groups />
 					</FunctionSet>
 				</PrescribedController>
-				<PrescribedController name="R-everter controls">
+				<PrescribedController name="R-everter-controls">
 					<!--Flag (true or false) indicating whether or not the controller is disabled.-->
 					<isDisabled>true</isDisabled>
 					<!--The list of model actuators that this controller will control.The keyword ALL indicates the controller will controll all the acuators in the model-->

--- a/Models/ToyLanding/ToyLandingModel_activeAFO.osim
+++ b/Models/ToyLanding/ToyLandingModel_activeAFO.osim
@@ -8412,7 +8412,7 @@
 						<objects>
 							<HuntCrossleyForce::ContactParameters>
 								<!--Names of geometry objects affected by these parameters.-->
-								<geometry>platform heel_r ball_big_toe_r small_toe_r</geometry>
+								<geometry>platformSurface heel_r ball_big_toe_r small_toe_r</geometry>
 								<stiffness>100000000</stiffness>
 								<dissipation>0.5</dissipation>
 								<static_friction>0.9</static_friction>
@@ -8433,7 +8433,7 @@
 						<objects>
 							<HuntCrossleyForce::ContactParameters>
 								<!--Names of geometry objects affected by these parameters.-->
-								<geometry>platform heel_l ball_big_toe_l small_toe_l</geometry>
+								<geometry>platformSurface heel_l ball_big_toe_l small_toe_l</geometry>
 								<stiffness>100000000</stiffness>
 								<dissipation>0.5</dissipation>
 								<static_friction>0.9</static_friction>
@@ -8690,7 +8690,7 @@
 		<!--ContactGeometries  in the model.-->
 		<ContactGeometrySet>
 			<objects>
-				<ContactHalfSpace name="platform">
+				<ContactHalfSpace name="platformSurface">
 					<!--Body name to connect the contact geometry to-->
 					<body_name>platform</body_name>
 					<!--Location of geometry center in the body frame-->

--- a/Models/ToyLanding/ToyLandingModel_activeAFO.osim
+++ b/Models/ToyLanding/ToyLandingModel_activeAFO.osim
@@ -8412,7 +8412,7 @@
 						<objects>
 							<HuntCrossleyForce::ContactParameters>
 								<!--Names of geometry objects affected by these parameters.-->
-								<geometry>platformSurface heel_r ball_big_toe_r small_toe_r</geometry>
+								<geometry>platform_surface heel_r ball_big_toe_r small_toe_r</geometry>
 								<stiffness>100000000</stiffness>
 								<dissipation>0.5</dissipation>
 								<static_friction>0.9</static_friction>
@@ -8433,7 +8433,7 @@
 						<objects>
 							<HuntCrossleyForce::ContactParameters>
 								<!--Names of geometry objects affected by these parameters.-->
-								<geometry>platformSurface heel_l ball_big_toe_l small_toe_l</geometry>
+								<geometry>platform_surface heel_l ball_big_toe_l small_toe_l</geometry>
 								<stiffness>100000000</stiffness>
 								<dissipation>0.5</dissipation>
 								<static_friction>0.9</static_friction>
@@ -8690,7 +8690,7 @@
 		<!--ContactGeometries  in the model.-->
 		<ContactGeometrySet>
 			<objects>
-				<ContactHalfSpace name="platformSurface">
+				<ContactHalfSpace name="platform_surface">
 					<!--Body name to connect the contact geometry to-->
 					<body_name>platform</body_name>
 					<!--Location of geometry center in the body frame-->


### PR DESCRIPTION
Fixes #48. Also updated names of PrescribedControllers to avoid rename warning due to whitespace. All 3 models open and simulate using AppVeyor artifact OpenSim-2fd23ef3-2018-02-20.zip from opensim-gui repo. Did not re-save in 4.0, so Messages window still reports
<pre>
Updating Model file from 30000 to latest format...
</pre>
Unclear whether we want to re-save in 4.0 as that makes the files longer (also see #46).