### PR TITLE
Avoid "duplicate name" warnings due to assignment of default names

### DIFF
--- a/Tutorials/Computed_Muscle_Control/InverseKinematics/arm26.osim
+++ b/Tutorials/Computed_Muscle_Control/InverseKinematics/arm26.osim
@@ -1052,17 +1052,17 @@
 						</VisibleObject>
 						<PathWrapSet>
 							<objects>
-								<PathWrap>
+								<PathWrap name="TRIlong-wrap-cylinder1">
 									<wrap_object>TRI</wrap_object>
 									<method>hybrid</method>
 									<range> -1 -1</range>
 								</PathWrap>
-								<PathWrap>
+								<PathWrap name="TRIlong-wrap-ellipsoid">
 									<wrap_object>TRIlonghh</wrap_object>
 									<method>hybrid</method>
 									<range> -1 -1</range>
 								</PathWrap>
-								<PathWrap>
+								<PathWrap name="TRIlong-wrap-cylinder2">
 									<wrap_object>TRIlongglen</wrap_object>
 									<method>hybrid</method>
 									<range> -1 -1</range>

--- a/Tutorials/Computed_Muscle_Control/OutputReference/arm26.osim
+++ b/Tutorials/Computed_Muscle_Control/OutputReference/arm26.osim
@@ -1065,17 +1065,17 @@
 						</VisibleObject>
 						<PathWrapSet>
 							<objects>
-								<PathWrap>
+								<PathWrap name="TRIlong-wrap-cylinder1">
 									<wrap_object>TRI</wrap_object>
 									<method>hybrid</method>
 									<range> -1 -1</range>
 								</PathWrap>
-								<PathWrap>
+								<PathWrap name="TRIlong-wrap-ellipsoid">
 									<wrap_object>TRIlonghh</wrap_object>
 									<method>hybrid</method>
 									<range> -1 -1</range>
 								</PathWrap>
-								<PathWrap>
+								<PathWrap name="TRIlong-wrap-cylinder2">
 									<wrap_object>TRIlongglen</wrap_object>
 									<method>hybrid</method>
 									<range> -1 -1</range>

--- a/Tutorials/Computed_Muscle_Control/OutputReference/arm26_with_bucket.osim
+++ b/Tutorials/Computed_Muscle_Control/OutputReference/arm26_with_bucket.osim
@@ -1065,17 +1065,17 @@
 						</VisibleObject>
 						<PathWrapSet>
 							<objects>
-								<PathWrap>
+								<PathWrap name="TRIlong-wrap-cylinder1">
 									<wrap_object>TRI</wrap_object>
 									<method>hybrid</method>
 									<range> -1 -1</range>
 								</PathWrap>
-								<PathWrap>
+								<PathWrap name="TRIlong-wrap-ellipsoid">
 									<wrap_object>TRIlonghh</wrap_object>
 									<method>hybrid</method>
 									<range> -1 -1</range>
 								</PathWrap>
-								<PathWrap>
+								<PathWrap name="TRIlong-wrap-cylinder2">
 									<wrap_object>TRIlongglen</wrap_object>
 									<method>hybrid</method>
 									<range> -1 -1</range>


### PR DESCRIPTION
Nameless Components are assigned default names in 4.0, which triggered "duplicate name" warnings on Model load. Assigned unique names to avoid warning messages. Analogous to changes made in PR #50. Fixes #55.