### PR TITLE
Move models up so they appear above the floor when opened in the 4.0 GUI

### DIFF
--- a/Pipelines/Gait10dof18musc/OutputReference/CMC/subject01_metabolics.osim
+++ b/Pipelines/Gait10dof18musc/OutputReference/CMC/subject01_metabolics.osim
@@ -106,7 +106,7 @@
 										<!--Coordinate can describe rotational, translational, or coupled motion. Defaults to rotational.-->
 										<motion_type>translational</motion_type>
 										<!--The value of this coordinate before any value has been set. Rotational coordinate value is in radians and Translational in meters.-->
-										<default_value>0</default_value>
+										<default_value>1.015</default_value>
 										<!--The speed value of this coordinate before any value has been set. Rotational coordinate value is in rad/s and Translational in m/s.-->
 										<default_speed_value>0</default_speed_value>
 										<!--The minimum and maximum values that the coordinate can range between. Rotational coordinate range in radians and Translational in meters.-->

--- a/Pipelines/Gait10dof18musc/OutputReference/CMC/subject01_metabolics_path_actuator.osim
+++ b/Pipelines/Gait10dof18musc/OutputReference/CMC/subject01_metabolics_path_actuator.osim
@@ -106,7 +106,7 @@
 										<!--Coordinate can describe rotational, translational, or coupled motion. Defaults to rotational.-->
 										<motion_type>translational</motion_type>
 										<!--The value of this coordinate before any value has been set. Rotational coordinate value is in radians and Translational in meters.-->
-										<default_value>0</default_value>
+										<default_value>1.015</default_value>
 										<!--The speed value of this coordinate before any value has been set. Rotational coordinate value is in rad/s and Translational in m/s.-->
 										<default_speed_value>0</default_speed_value>
 										<!--The minimum and maximum values that the coordinate can range between. Rotational coordinate range in radians and Translational in meters.-->

--- a/Pipelines/Gait10dof18musc/OutputReference/CMC/subject01_metabolics_path_spring.osim
+++ b/Pipelines/Gait10dof18musc/OutputReference/CMC/subject01_metabolics_path_spring.osim
@@ -106,7 +106,7 @@
 										<!--Coordinate can describe rotational, translational, or coupled motion. Defaults to rotational.-->
 										<motion_type>translational</motion_type>
 										<!--The value of this coordinate before any value has been set. Rotational coordinate value is in radians and Translational in meters.-->
-										<default_value>0</default_value>
+										<default_value>1.015</default_value>
 										<!--The speed value of this coordinate before any value has been set. Rotational coordinate value is in rad/s and Translational in m/s.-->
 										<default_speed_value>0</default_speed_value>
 										<!--The minimum and maximum values that the coordinate can range between. Rotational coordinate range in radians and Translational in meters.-->

--- a/Pipelines/Gait10dof18musc/OutputReference/CMC/subject01_metabolics_spring.osim
+++ b/Pipelines/Gait10dof18musc/OutputReference/CMC/subject01_metabolics_spring.osim
@@ -106,7 +106,7 @@
 										<!--Coordinate can describe rotational, translational, or coupled motion. Defaults to rotational.-->
 										<motion_type>translational</motion_type>
 										<!--The value of this coordinate before any value has been set. Rotational coordinate value is in radians and Translational in meters.-->
-										<default_value>0</default_value>
+										<default_value>1.015</default_value>
 										<!--The speed value of this coordinate before any value has been set. Rotational coordinate value is in rad/s and Translational in m/s.-->
 										<default_speed_value>0</default_speed_value>
 										<!--The minimum and maximum values that the coordinate can range between. Rotational coordinate range in radians and Translational in meters.-->

--- a/Pipelines/Gait10dof18musc/OutputReference/gait10dof18musc.osim
+++ b/Pipelines/Gait10dof18musc/OutputReference/gait10dof18musc.osim
@@ -106,7 +106,7 @@
 										<!--Coordinate can describe rotational, translational, or coupled motion. Defaults to rotational.-->
 										<motion_type>translational</motion_type>
 										<!--The value of this coordinate before any value has been set. Rotational coordinate value is in radians and Translational in meters.-->
-										<default_value>0</default_value>
+										<default_value>0.95</default_value>
 										<!--The speed value of this coordinate before any value has been set. Rotational coordinate value is in rad/s and Translational in m/s.-->
 										<default_speed_value>0</default_speed_value>
 										<!--The minimum and maximum values that the coordinate can range between. Rotational coordinate range in radians and Translational in meters.-->

--- a/Pipelines/Gait10dof18musc/OutputReference/subject01.osim
+++ b/Pipelines/Gait10dof18musc/OutputReference/subject01.osim
@@ -106,7 +106,7 @@
 										<!--Coordinate can describe rotational, translational, or coupled motion. Defaults to rotational.-->
 										<motion_type>translational</motion_type>
 										<!--The value of this coordinate before any value has been set. Rotational coordinate value is in radians and Translational in meters.-->
-										<default_value>0</default_value>
+										<default_value>1.015</default_value>
 										<!--The speed value of this coordinate before any value has been set. Rotational coordinate value is in rad/s and Translational in m/s.-->
 										<default_speed_value>0</default_speed_value>
 										<!--The minimum and maximum values that the coordinate can range between. Rotational coordinate range in radians and Translational in meters.-->

--- a/Pipelines/Gait2354_Simbody/OutputReference/subject01_scaledOnly.osim
+++ b/Pipelines/Gait2354_Simbody/OutputReference/subject01_scaledOnly.osim
@@ -165,7 +165,7 @@
 										<!--Coordinate can describe rotational, translational, or coupled motion. Defaults to rotational.-->
 										<motion_type>translational</motion_type>
 										<!--The value of this coordinate before any value has been set. Rotational coordinate value is in radians and Translational in meters.-->
-										<default_value>0</default_value>
+										<default_value>1.015</default_value>
 										<!--The speed value of this coordinate before any value has been set. Rotational coordinate value is in rad/s and Translational in m/s.-->
 										<default_speed_value>0</default_speed_value>
 										<!--The minimum and maximum values that the coordinate can range between. Rotational coordinate range in radians and Translational in meters.-->

--- a/Pipelines/Gait2354_Simbody/OutputReference/subject01_simbody.osim
+++ b/Pipelines/Gait2354_Simbody/OutputReference/subject01_simbody.osim
@@ -164,7 +164,7 @@
 										<!--Coordinate can describe rotational, translational, or coupled motion. Defaults to rotational.-->
 										<motion_type>translational</motion_type>
 										<!--The value of this coordinate before any value has been set. Rotational coordinate value is in radians and Translational in meters.-->
-										<default_value>0</default_value>
+										<default_value>1.015</default_value>
 										<!--The speed value of this coordinate before any value has been set. Rotational coordinate value is in rad/s and Translational in m/s.-->
 										<default_speed_value>0</default_speed_value>
 										<!--The minimum and maximum values that the coordinate can range between. Rotational coordinate range in radians and Translational in meters.-->

--- a/Pipelines/Gait2354_Simbody/OutputReference/subject01_simbody_adjusted.osim
+++ b/Pipelines/Gait2354_Simbody/OutputReference/subject01_simbody_adjusted.osim
@@ -164,7 +164,7 @@
 										<!--Coordinate can describe rotational, translational, or coupled motion. Defaults to rotational.-->
 										<motion_type>translational</motion_type>
 										<!--The value of this coordinate before any value has been set. Rotational coordinate value is in radians and Translational in meters.-->
-										<default_value>0</default_value>
+										<default_value>1.015</default_value>
 										<!--The speed value of this coordinate before any value has been set. Rotational coordinate value is in rad/s and Translational in m/s.-->
 										<default_speed_value>0</default_speed_value>
 										<!--The minimum and maximum values that the coordinate can range between. Rotational coordinate range in radians and Translational in meters.-->

--- a/Pipelines/Gait2392_Simbody/OutputReference/subject01_simbody.osim
+++ b/Pipelines/Gait2392_Simbody/OutputReference/subject01_simbody.osim
@@ -14484,9 +14484,9 @@
 										<!--Cooridnate can describe rotational, translational, or coupled values.
 										    Defaults to rotational.-->
 										<motion_type> translational </motion_type>
-										<default_value>   0.00000000 </default_value>
+										<default_value>   1.015 </default_value>
 										<default_speed_value>   0.00000000 </default_speed_value>
-										<initial_value>   0.00000000 </initial_value>
+										<initial_value>   1.015 </initial_value>
 										<range>  -1.00000000   2.00000000 </range>
 										<clamped> false </clamped>
 										<locked> false </locked>

--- a/Pipelines/Gait2392_Simbody/OutputReference/subject01_simbody_adjusted.osim
+++ b/Pipelines/Gait2392_Simbody/OutputReference/subject01_simbody_adjusted.osim
@@ -14485,9 +14485,9 @@
 										<!--Cooridnate can describe rotational, translational, or coupled values.
 										    Defaults to rotational.-->
 										<motion_type> translational </motion_type>
-										<default_value>       0.00000000 </default_value>
+										<default_value>       1.015 </default_value>
 										<default_speed_value>       0.00000000 </default_speed_value>
-										<initial_value>       0.00000000 </initial_value>
+										<initial_value>       1.015 </initial_value>
 										<range>      -1.00000000       2.00000000 </range>
 										<clamped> false </clamped>
 										<locked> false </locked>


### PR DESCRIPTION
Addresses part of #56.

Uses the same offsets as in PR #42: moves `pelvis_ty` of gait10dof18musc and derivative models to 0.95; moves `pelvis_ty` of subject01 and derivative models to 1.015.

Edited .osim files in text editor to avoid converting file to new version. Verified by loading in GUI (AppVeyor artifact OpenSim-2fd23ef3-2018-02-20.zip).