### PR TITLE
Enable Soccer model to load with out errors

### DIFF
--- a/Models/SoccerKick/SoccerKickingModel.osim
+++ b/Models/SoccerKick/SoccerKickingModel.osim
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <OpenSimDocument Version="30000">
-	<Model name="Soccer Ball Kicking Model">
+	<Model name="SoccerBallKickingModel">
 		<credits>Seth A., Reinbolt J.A, Delp D., Hamner S., Habib A., Delp S.L., Loan J.P.</credits>
 		<publications>Notes: 2D, 6 DOF leg model created by Jeff Reinbolt, Ajay Seth, and Scott L. Delp, Stanford University. Lower extremity joint defintions based on Delp et al. (1990). Number of muscles was reduced by Reinbolt to improve simulation speed for demonstrations and is not intended to be used in research. Number of constraints reduced by A. Seth. Foot-ball-ground contact added by A. Seth. Soccer ball and goal added by Seth using OpenSim geometry created by Denny Delp. Graphics for ball and customized GUI by Ayman Habib Backstop of net and full body model contributed by Samuel Hamner and added by A. Seth Goalie is the "Freebie Man 3d model" from http://thefree3dmodels.com/stuff/characters/freebie_man/14-1-0-1166 and added by A. Seth</publications>
 		<length_units>meters</length_units>

--- a/Models/SoccerKick/SoccerKickingModel.osim
+++ b/Models/SoccerKick/SoccerKickingModel.osim
@@ -4153,7 +4153,7 @@
 					<!--Transition region width in the units of the coordinate (rotations in degrees). Dictates the transition from zero to constant stiffness as coordinate exceeds its limit.-->
 					<transition>2</transition>
 				</CoordinateLimitForce>
-				<HuntCrossleyForce name="foot_ground">
+				<HuntCrossleyForce name="foot_floor">
 					<!--Flag indicating whether the force is disabled or not. Disabled means that the force is not active in subsequent dynamics realizations.-->
 					<isDisabled>false</isDisabled>
 					<!--Material properties.-->
@@ -4161,7 +4161,7 @@
 						<objects>
 							<HuntCrossleyForce::ContactParameters>
 								<!--Names of geometry objects affected by these parameters.-->
-								<geometry>ground ball_big_toe_r tip_big_toe_r small_toe_r</geometry>
+								<geometry>floor ball_big_toe_r tip_big_toe_r small_toe_r</geometry>
 								<stiffness>10000000</stiffness>
 								<dissipation>0.005</dissipation>
 								<static_friction>0.2</static_friction>
@@ -4182,7 +4182,7 @@
 						<objects>
 							<HuntCrossleyForce::ContactParameters>
 								<!--Names of geometry objects affected by these parameters.-->
-								<geometry>ball ball_big_toe_r tip_big_toe_r small_toe_r</geometry>
+								<geometry>soccer_ball ball_big_toe_r tip_big_toe_r small_toe_r</geometry>
 								<stiffness>1000000</stiffness>
 								<dissipation>0.005</dissipation>
 								<static_friction>0.7</static_friction>
@@ -4203,7 +4203,7 @@
 						<objects>
 							<HuntCrossleyForce::ContactParameters>
 								<!--Names of geometry objects affected by these parameters.-->
-								<geometry>ground ball</geometry>
+								<geometry>floor soccer_ball</geometry>
 								<stiffness>1000000</stiffness>
 								<dissipation>0.1</dissipation>
 								<static_friction>0.7</static_friction>
@@ -4224,7 +4224,7 @@
 						<objects>
 							<HuntCrossleyForce::ContactParameters>
 								<!--Names of geometry objects affected by these parameters.-->
-								<geometry>back_stop ball</geometry>
+								<geometry>back_stop soccer_ball</geometry>
 								<stiffness>50000</stiffness>
 								<dissipation>0.2</dissipation>
 								<static_friction>0.7</static_friction>
@@ -4245,7 +4245,7 @@
 						<objects>
 							<HuntCrossleyForce::ContactParameters>
 								<!--Names of geometry objects affected by these parameters.-->
-								<geometry>ball goalie_head goalie_hand_r goalie_hand_l goalie_torso goalie_foot_r goalie_foot_l goalie_knee_r goalie_knee_l goalie_elbow_r goalie_elbow_l</geometry>
+								<geometry>soccer_ball goalie_head goalie_hand_r goalie_hand_l goalie_torso goalie_foot_r goalie_foot_l goalie_knee_r goalie_knee_l goalie_elbow_r goalie_elbow_l</geometry>
 								<stiffness>500000</stiffness>
 								<dissipation>0.2</dissipation>
 								<static_friction>0.7</static_friction>
@@ -4269,7 +4269,7 @@
 		<!--ContactGeometries  in the model.-->
 		<ContactGeometrySet>
 			<objects>
-				<ContactHalfSpace name="ground">
+				<ContactHalfSpace name="floor">
 					<!--Body name to connect the contact geometry to-->
 					<body_name>ground</body_name>
 					<!--Location of geometry center in the body frame-->
@@ -4279,7 +4279,7 @@
 					<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 					<display_preference>0</display_preference>
 				</ContactHalfSpace>
-				<ContactSphere name="ball">
+				<ContactSphere name="soccer_ball">
 					<!--Body name to connect the contact geometry to-->
 					<body_name>ball</body_name>
 					<!--Location of geometry center in the body frame-->

--- a/Models/SoccerKick/controls_kick.xml
+++ b/Models/SoccerKick/controls_kick.xml
@@ -1,0 +1,6018 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OpenSimDocument Version="20302">
+	<ControlSet name="Control Set">
+		<objects>
+			<ControlLinear name="bifemlh_r">
+				<is_model_control> true </is_model_control>
+				<extrapolate> true </extrapolate>
+				<default_min>       0.02000000 </default_min>
+				<default_max>       1.00000000 </default_max>
+				<filter_on> false </filter_on>
+				<use_steps> false </use_steps>
+				<x_nodes>
+					<ControlLinearNode name="">
+						<t>       0.11216261 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.11397011 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.11630540 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.11851034 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.12071529 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.12292023 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.12435628 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.12515161 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.12594695 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.12775095 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.12874553 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.12974011 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.13344647 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.13715283 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.14296033 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.14779574 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.15263115 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.15585497 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.15907880 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.16356884 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.16668665 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.16980446 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.17359359 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.17701856 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.18044353 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.19232494 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.19574991 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.19917487 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.20259984 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.20544916 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.20829848 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.21230496 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.21539332 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.21848169 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.22157005 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.22491197 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.22825389 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.23111359 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.23397330 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.23766830 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.24050668 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.24334505 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.24618343 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.24968706 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.25319068 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.25564690 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.25810312 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.26179160 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.26509580 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.26777007 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.27044433 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.27375637 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.27706840 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.27964705 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.28222571 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.28552983 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.28883396 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.29147882 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.29412368 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.29742909 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.30073450 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.30326170 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.30578891 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.30920829 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.31262768 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.31505433 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.31748098 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.32110476 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.32412390 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.32425541 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.32727455 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.33029368 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.33331282 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.33590680 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.33850078 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.34207459 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.34478576 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.34749694 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.35090481 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.35396675 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.35702869 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.36009063 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.36315257 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.36621451 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.36927646 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.37196740 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.37465834 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.37805569 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.38145303 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.38403413 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.38661523 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.39028661 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.39346755 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.39664849 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.39946358 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.40227866 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.40509374 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.40883170 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.41169452 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.41300715 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.41382522 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.41454232 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.41525942 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.41829561 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.42133179 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.42436797 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.43122772 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.43623378 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.43914890 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.44206402 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.44557327 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.44856008 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.45154690 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.45453371 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.45752053 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.45752053 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.45968999 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.46258778 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.46548556 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.46977365 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.47406173 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.47716356 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.48026540 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.48404156 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.48683043 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.48961930 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.49332818 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.49703705 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.49972113 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.50240522 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.50631710 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.50973096 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.51554005 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.51895391 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.52185345 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.52475299 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.52836142 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.53196984 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.53505452 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.53813921 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.54564695 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.56383426 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.56690882 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.56998337 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.57305793 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.57732681 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.58030258 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.58327835 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.58625412 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.59127824 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.59396986 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.59666148 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.60126305 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.60583550 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.60948536 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.61264453 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.61580370 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.62045493 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.62335928 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.62626362 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.63055502 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.64577700 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.66398212 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+				</x_nodes>
+				<min_nodes/>
+				<max_nodes/>
+				<kp>     100.00000000 </kp>
+				<kv>      20.00000000 </kv>
+			</ControlLinear>
+			<ControlLinear name="bifemsh_r">
+				<is_model_control> true </is_model_control>
+				<extrapolate> true </extrapolate>
+				<default_min>       0.02000000 </default_min>
+				<default_max>       1.00000000 </default_max>
+				<filter_on> false </filter_on>
+				<use_steps> false </use_steps>
+				<x_nodes>
+					<ControlLinearNode name="">
+						<t>       0.09811629 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.09992379 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.10225908 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.10446402 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.10666897 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.10887391 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.11030996 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.11110529 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.11190063 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.11370463 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.11469921 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.11569379 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.11940015 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.12310651 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.12891401 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.13374942 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.13858483 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.14180865 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.14503248 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.14952252 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.15264033 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.15575814 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.15954727 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.16297224 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.16639721 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.16982218 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.17324715 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.17667211 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.18009708 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.18294640 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.18579572 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.18980220 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.19289056 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.19597893 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.19906729 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.20240921 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.20575113 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.20861083 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.21147054 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.21516554 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.21800392 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.22084229 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.22368067 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.22718430 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.23068792 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.23314414 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.23560036 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.23928884 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.24259304 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.24526731 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.24794157 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.25125361 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.25456564 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.25714429 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.25972295 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.26302707 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.26633120 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.26897606 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.27162092 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.27492633 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.27823174 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.28075894 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.28328615 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.28670553 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.29012492 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.29255157 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.30100112 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.30462490 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.30764404 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.31066317 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.31368231 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.31670144 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.31972058 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.32231456 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.32490854 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.32848235 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.33119352 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.33390470 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.33731257 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.34037451 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.34343645 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.34601755 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.34907949 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.35214143 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.35520338 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.35789432 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.36058526 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.36398261 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.36398261 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.36656371 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.36656371 </t>
+						<value>       0.69287199 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.37023509 </t>
+						<value>       0.69287199 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.37341603 </t>
+						<value>       0.69287199 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.37659697 </t>
+						<value>       0.69287199 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.37941206 </t>
+						<value>       0.69287199 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.38222714 </t>
+						<value>       0.69287199 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.38504222 </t>
+						<value>       0.69287199 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.38878018 </t>
+						<value>       0.69287199 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.39164300 </t>
+						<value>       0.69287199 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.39295563 </t>
+						<value>       0.69287199 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.39295563 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.39367273 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.39438983 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.39742602 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.40046220 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.40349838 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.40734013 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.41234619 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.41526131 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.41817643 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.42168568 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.42467249 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.42765931 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.43064612 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.43363294 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.43738237 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.43955183 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.46532302 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.46822080 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.47250889 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.48117070 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.48427253 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.49329142 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.49706758 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.49985645 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.50264532 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.50635420 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.51006307 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.51274715 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.51543124 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.51934312 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.52275698 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.53180386 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.53521772 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.53811726 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.54101680 </t>
+						<value>       0.40000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.54462523 </t>
+						<value>       0.40000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.54823365 </t>
+						<value>       0.40000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.55131833 </t>
+						<value>       0.40000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.55440302 </t>
+						<value>       0.40000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.55748770 </t>
+						<value>       0.40000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.56145134 </t>
+						<value>       0.40000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.56452590 </t>
+						<value>       0.40000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.56760045 </t>
+						<value>       0.40000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.57067501 </t>
+						<value>       0.40000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.57494389 </t>
+						<value>       0.40000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.57494389 </t>
+						<value>       0.40000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.57791966 </t>
+						<value>       0.40000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.58089543 </t>
+						<value>       0.40000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.58591955 </t>
+						<value>       0.40000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.58861117 </t>
+						<value>       0.40000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.59130279 </t>
+						<value>       0.40000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.59590436 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.60047681 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.60412667 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.60728584 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.61044501 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.61509624 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.61800059 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.62090493 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.62519633 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.62905124 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.65066542 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+				</x_nodes>
+				<min_nodes/>
+				<max_nodes/>
+				<kp>     100.00000000 </kp>
+				<kv>      20.00000000 </kv>
+			</ControlLinear>
+			<ControlLinear name="glut_max2_r">
+				<is_model_control> true </is_model_control>
+				<extrapolate> true </extrapolate>
+				<default_min>       0.02000000 </default_min>
+				<default_max>       1.00000000 </default_max>
+				<filter_on> false </filter_on>
+				<use_steps> false </use_steps>
+				<x_nodes>
+					<ControlLinearNode name="">
+						<t>       0.09090731 </t>
+						<value>       0.03625087 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.09271481 </t>
+						<value>       0.03625087 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.09505010 </t>
+						<value>       0.03625087 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.09725504 </t>
+						<value>       0.03625087 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.09945999 </t>
+						<value>       0.03625087 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.10166493 </t>
+						<value>       0.03625087 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.10310098 </t>
+						<value>       0.03625087 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.10389631 </t>
+						<value>       0.03625087 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.10469165 </t>
+						<value>       0.03625087 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.10649565 </t>
+						<value>       0.03625087 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.10749023 </t>
+						<value>       0.03625087 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.10848481 </t>
+						<value>       0.03625087 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.11219117 </t>
+						<value>       0.03625087 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.11589753 </t>
+						<value>       0.03625087 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.12170503 </t>
+						<value>       0.03625087 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.12654044 </t>
+						<value>       0.03625087 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.14793177 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.15115559 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.15437942 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.15886946 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.16198727 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.16510508 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.16889421 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.17231918 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.17574415 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.17916912 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.18259409 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.18601905 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.18944402 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.19229334 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.19514266 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.19914914 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.20223750 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.21486264 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.21795100 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.22129292 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.22463484 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.22749454 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.23035425 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.23404925 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.23688763 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.23972600 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.24256438 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.24606801 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.24957163 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.25202785 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.25448407 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.25817255 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.26147675 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.26415102 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.26682528 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.27013732 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.27344935 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.27602800 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.27860666 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.28191078 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.28521491 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.28785977 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.29050463 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.29381004 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.29711545 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.29964265 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.30216986 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.30558924 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.30900863 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.31143528 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.31386193 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.31748571 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.32050485 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.32352398 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.32654312 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.32956225 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.33258139 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.33517537 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.33776935 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.34134316 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.34405433 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.34676551 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.35017338 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.35323532 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.35629726 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.35935920 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.36242114 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.36548308 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.36854503 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.37123597 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.37392691 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.37732426 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.38072160 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.38330270 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.38588380 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.38955518 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.39273612 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.39591706 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.39873215 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.40154723 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.40436231 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.40810027 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.41096309 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.41227572 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.41309379 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.41381089 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.41452799 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.41756418 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.42060036 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.42363654 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.42747829 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.43248435 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.43539947 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.43831459 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.44182384 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.44481065 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.44779747 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.45078428 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.45377110 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.45752053 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.45968999 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.46258778 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.46548556 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.46977365 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.47406173 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.47716356 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.48026540 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.48404156 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.48683043 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.48961930 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.49332818 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.49703705 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.49972113 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.50240522 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.50631710 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.50973096 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.51314481 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.51655867 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.51945821 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.52235775 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.52596618 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.52957460 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.53265928 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.53574397 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.53882865 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.54279229 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.54586685 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.54894140 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.55201596 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.55628484 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.55926061 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.56223638 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.56521215 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.57023627 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.57292789 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.57561951 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.58022108 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.58479353 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.58844339 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.59160256 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.59476173 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.59941296 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.60231731 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.60522165 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.60951305 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.61336796 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.61700000 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+				</x_nodes>
+				<min_nodes/>
+				<max_nodes/>
+				<kp>     100.00000000 </kp>
+				<kv>      20.00000000 </kv>
+			</ControlLinear>
+			<ControlLinear name="psoas_r">
+				<is_model_control> true </is_model_control>
+				<extrapolate> true </extrapolate>
+				<default_min>       0.02000000 </default_min>
+				<default_max>       1.00000000 </default_max>
+				<filter_on> false </filter_on>
+				<use_steps> false </use_steps>
+				<x_nodes>
+					<ControlLinearNode name="">
+						<t>       0.09684153 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.09864903 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.10098432 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.10318926 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.10539421 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.10759915 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.10903520 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.10983053 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.11062587 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.11242987 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.11342445 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.11441903 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.11812539 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.12374463 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.12955213 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.13438754 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.13922295 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.14244677 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.14567060 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.15016064 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.15327845 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.15639626 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.16018539 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.16361036 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.16703533 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.17046030 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.17388527 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.17731023 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.18073520 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.18358452 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.18643384 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.19044032 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.19352868 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.19661705 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.19970541 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.20304733 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.20638925 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.20924895 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.21210866 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.21580366 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.21864204 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.22148041 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.22190865 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.22541228 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.22891590 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.23137212 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.23382834 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.23751682 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.23751682 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.24019109 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.24286535 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.24617739 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.24948942 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.25206807 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.25464673 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.25795085 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.26125498 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.26389984 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.26654470 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.26985011 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.27315552 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.27568272 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.27820993 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.28162931 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.28504870 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.28747535 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.28990200 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.29352578 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.29654492 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.29956405 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.30258319 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.31885937 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.32187851 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.32447249 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.32706647 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.33064028 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.33335145 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.33606263 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.33947050 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.34253244 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.34559438 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.34865632 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.35171826 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.35478020 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.35784215 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.36053309 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.36322403 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.36662138 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.37001872 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.37259982 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.37518092 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.37885230 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.38203324 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.38521418 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.38802927 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.39084435 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.40624401 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.40998197 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.41284479 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.41415742 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.41497549 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.41569259 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.41640969 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.41944588 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.42248206 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.42551824 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.42935999 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.43436605 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.43728117 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.44019629 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.44370554 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.44669235 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.45150635 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.45449316 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.45747998 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.46122941 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.46339887 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.46629666 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.46919444 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.47348253 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.47777061 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.48087244 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.48397428 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.48775044 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.49053931 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.49332818 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.49332818 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.49703705 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.49972113 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.50240522 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.50631710 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.50973096 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.51314481 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.51655867 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.51945821 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.52235775 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.52596618 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.52957460 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.53265928 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.53574397 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.53882865 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.54279229 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.54586685 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.54894140 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.55201596 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.55628484 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.55926061 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.56223638 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.56521215 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.57023627 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.57292789 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.57561951 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.58022108 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.58479353 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.58844339 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.59160256 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.59476173 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.59941296 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.60231731 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.60522165 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.60951305 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.61336796 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.61700000 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+				</x_nodes>
+				<min_nodes/>
+				<max_nodes/>
+				<kp>     100.00000000 </kp>
+				<kv>      20.00000000 </kv>
+			</ControlLinear>
+			<ControlLinear name="rect_fem_r">
+				<is_model_control> true </is_model_control>
+				<extrapolate> true </extrapolate>
+				<default_min>       0.02000000 </default_min>
+				<default_max>       1.00000000 </default_max>
+				<filter_on> false </filter_on>
+				<use_steps> false </use_steps>
+				<x_nodes>
+					<ControlLinearNode name="">
+						<t>       0.10609430 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.10790180 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.11023709 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.11244203 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.11464698 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.11685192 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.11828797 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.11908330 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.11987864 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.12168264 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.12267722 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.12367180 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.12737816 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.13108452 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.13689202 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.14172743 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.14656284 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.14978666 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.15301049 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.15750053 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.16061834 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.16373615 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.16752528 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.17095025 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.17437522 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.17780019 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.18122516 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.18465012 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.18807509 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.19092441 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.19377373 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.19778021 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.20086857 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.20086857 </t>
+						<value>       0.23741175 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.20395693 </t>
+						<value>       0.23741175 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.20729885 </t>
+						<value>       0.23741175 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.21064077 </t>
+						<value>       0.23741175 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.21350047 </t>
+						<value>       0.23741175 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.21636018 </t>
+						<value>       0.23741175 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.22005518 </t>
+						<value>       0.23741175 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.22289356 </t>
+						<value>       0.23741175 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.22573193 </t>
+						<value>       0.23741175 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.22857031 </t>
+						<value>       0.23741175 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.23207394 </t>
+						<value>       0.23741175 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.23557756 </t>
+						<value>       0.23741175 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.23803378 </t>
+						<value>       0.23741175 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.24049000 </t>
+						<value>       0.23741175 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.24417848 </t>
+						<value>       0.23741175 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.24748268 </t>
+						<value>       0.23741175 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.25015695 </t>
+						<value>       0.23741175 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.25283121 </t>
+						<value>       0.23741175 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.25614325 </t>
+						<value>       0.23741175 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.29054883 </t>
+						<value>       0.86530517 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.29312748 </t>
+						<value>       0.86530517 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.29570614 </t>
+						<value>       0.86530517 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.29901026 </t>
+						<value>       0.86530517 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.30231439 </t>
+						<value>       0.86530517 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.30495925 </t>
+						<value>       0.86530517 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.30760411 </t>
+						<value>       0.86530517 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.31090952 </t>
+						<value>       0.86530517 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.31421493 </t>
+						<value>       0.86530517 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.31674213 </t>
+						<value>       0.86530517 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.31926934 </t>
+						<value>       0.86530517 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.32268872 </t>
+						<value>       0.86530517 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.32610811 </t>
+						<value>       0.86530517 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.32648304 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.32890969 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.33253347 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.33555261 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.33857174 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.34159088 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.34461001 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.34762915 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.35022313 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.35281711 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.35639092 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.35910209 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.36181327 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.36522114 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.36828308 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.37134502 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.37440696 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.37746890 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.38053084 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.38359279 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.38628373 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.38897467 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.39237202 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.39576936 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.39835046 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.40093156 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.40460294 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.40778388 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.41096482 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.41377991 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.41659499 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.41941007 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.42314803 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.42601085 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.42732348 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.42814155 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.42885865 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.42957575 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.43261194 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.43564812 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.43868430 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.44252605 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.44753211 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.45044723 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.45336235 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.45687160 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.45985841 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.46284523 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.46583204 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.46881886 </t>
+						<value>       0.86698717 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.46881886 </t>
+						<value>       0.40716937 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.47098832 </t>
+						<value>       0.40716937 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.47388611 </t>
+						<value>       0.40716937 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.47678389 </t>
+						<value>       0.40716937 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.48107198 </t>
+						<value>       0.40716937 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.48536006 </t>
+						<value>       0.40716937 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.48846189 </t>
+						<value>       0.40716937 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.49156373 </t>
+						<value>       0.40716937 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.49533989 </t>
+						<value>       0.40716937 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.49812876 </t>
+						<value>       0.40716937 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.50091763 </t>
+						<value>       0.40716937 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.50462651 </t>
+						<value>       0.40716937 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.50833538 </t>
+						<value>       0.40716937 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.51101946 </t>
+						<value>       0.40716937 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.51370355 </t>
+						<value>       0.40716937 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.51761543 </t>
+						<value>       0.40716937 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.52102929 </t>
+						<value>       0.40716937 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.52444314 </t>
+						<value>       0.40716937 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.52785700 </t>
+						<value>       0.40716937 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.53075654 </t>
+						<value>       0.40716937 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.53365608 </t>
+						<value>       0.40716937 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.53726451 </t>
+						<value>       0.40716937 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.54087293 </t>
+						<value>       0.40716937 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.54395761 </t>
+						<value>       0.40716937 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.54704230 </t>
+						<value>       0.40716937 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.56422572 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.56818936 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.57126392 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.57433847 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.57741303 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.58168191 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.58465768 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.58840711 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.59138288 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.59640700 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.59909862 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.60179024 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.60639181 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.61096426 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.61461412 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.61777329 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.62093246 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.63263305 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.63553740 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.63844174 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.64273314 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.64658805 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.65209988 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+				</x_nodes>
+				<min_nodes/>
+				<max_nodes/>
+				<kp>     100.00000000 </kp>
+				<kv>      20.00000000 </kv>
+			</ControlLinear>
+			<ControlLinear name="vas_int_r">
+				<is_model_control> true </is_model_control>
+				<extrapolate> true </extrapolate>
+				<default_min>       0.02000000 </default_min>
+				<default_max>       1.00000000 </default_max>
+				<filter_on> false </filter_on>
+				<use_steps> false </use_steps>
+				<x_nodes>
+					<ControlLinearNode name="">
+						<t>       0.11700000 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.11880750 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.12114279 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.12334773 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.12555268 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.12775762 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.12919367 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.12998900 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.13078434 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.13258834 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.13358292 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.13457750 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.13828386 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.14199022 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.14779772 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.15263313 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.15746854 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.16069236 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.16391619 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.16840623 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.17152404 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.17464185 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.17843098 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.18185595 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.18528092 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.18870589 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.19213086 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.19555582 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.19898079 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.20183011 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.20467943 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.20868591 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.21177427 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.21486264 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.21795100 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.22129292 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.22463484 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.22749454 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.23035425 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.23404925 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.23688763 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.23972600 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.24256438 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.24606801 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.24957163 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.25202785 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.25448407 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.25817255 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.26147675 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.26415102 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.26682528 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.27013732 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.27344935 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.27602800 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.27860666 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.28191078 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.28521491 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.28785977 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.29050463 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.29381004 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.29711545 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.29964265 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.30216986 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.30850436 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.31192375 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.31435040 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.31677705 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.32040083 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.32341997 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.32643910 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.32945824 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.33247737 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.33549651 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.33809049 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.34068447 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.34425828 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.34696945 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.34968063 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.35308850 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.35615044 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.38421238 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.38727432 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.39033626 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.39033626 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.39339821 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.39608915 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.39878009 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.40217744 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.40557478 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.40815588 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.41073698 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.41440836 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.41758930 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.42077024 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.42358533 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.42640041 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.42921549 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.45663303 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.45949585 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.46080848 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.46162655 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.46234365 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.46306075 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.46609694 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.46913312 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.47216930 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.47601105 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.48101711 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.48393223 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.48393223 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.48744148 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.49042829 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.49341511 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.49640192 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.49938874 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.50313817 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.50530763 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.50820542 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.51110320 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.51539129 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.51967937 </t>
+						<value>       0.22288544 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.52278120 </t>
+						<value>       0.22288544 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.52588304 </t>
+						<value>       0.22288544 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.52965920 </t>
+						<value>       0.22288544 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.53244807 </t>
+						<value>       0.22288544 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.53523694 </t>
+						<value>       0.22288544 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.53894582 </t>
+						<value>       0.22288544 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.54265469 </t>
+						<value>       0.22288544 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.54533877 </t>
+						<value>       0.22288544 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.54802286 </t>
+						<value>       0.22288544 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.55193474 </t>
+						<value>       0.22288544 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.55534860 </t>
+						<value>       0.22288544 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.55534860 </t>
+						<value>       0.12093724 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.55876246 </t>
+						<value>       0.12093724 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.56166200 </t>
+						<value>       0.12093724 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.56456154 </t>
+						<value>       0.12093724 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.56816997 </t>
+						<value>       0.12093724 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.57177839 </t>
+						<value>       0.12093724 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.57486307 </t>
+						<value>       0.12093724 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.57794776 </t>
+						<value>       0.12093724 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.58103244 </t>
+						<value>       0.12093724 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.58499608 </t>
+						<value>       0.12093724 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.58807064 </t>
+						<value>       0.12093724 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.59114519 </t>
+						<value>       0.12093724 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.59421975 </t>
+						<value>       0.12093724 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.59848863 </t>
+						<value>       0.12093724 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.60146440 </t>
+						<value>       0.12093724 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.60444017 </t>
+						<value>       0.12093724 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.60741594 </t>
+						<value>       0.12093724 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.61244006 </t>
+						<value>       0.12093724 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.61513168 </t>
+						<value>       0.12093724 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.61782330 </t>
+						<value>       0.12093724 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.62242487 </t>
+						<value>       0.12093724 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.62699732 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.63064718 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.63380635 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.63696552 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.64161675 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.64452110 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.64742544 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.65171684 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.67839206 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.68981948 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+				</x_nodes>
+				<min_nodes/>
+				<max_nodes/>
+				<kp>     100.00000000 </kp>
+				<kv>      20.00000000 </kv>
+			</ControlLinear>
+			<ControlLinear name="med_gas_r">
+				<is_model_control> true </is_model_control>
+				<extrapolate> true </extrapolate>
+				<default_min>       0.02000000 </default_min>
+				<default_max>       1.00000000 </default_max>
+				<filter_on> false </filter_on>
+				<use_steps> false </use_steps>
+				<x_nodes>
+					<ControlLinearNode name="">
+						<t>       0.11278544 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.11459294 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.11692823 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.11913317 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.12133812 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.12354306 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.12497911 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.12577444 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.12656978 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.12837378 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.12936836 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.13036294 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.13406930 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.13777566 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.14358316 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.14841857 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.15325398 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.15647780 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.15824068 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.16273072 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.16584853 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.16896634 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.17275547 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.17618044 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.17960541 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.18303038 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.18645535 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.18988031 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.19330528 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.19615460 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.19900392 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.20301040 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.20609876 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.20918713 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.21227549 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.21561741 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.21895933 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.22181903 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.22467874 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.22837374 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.23121212 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.23405049 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.23688887 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.24039250 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.24389612 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.24635234 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.25735215 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.26104063 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.26434483 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.26701910 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.26969336 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.27300540 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.27631743 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.27889608 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.28147474 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.28477886 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.28808299 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.29072785 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.29337271 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.29667812 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.29998353 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.30251073 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.30503794 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.30845732 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.31187671 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.31430336 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.31673001 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.32035379 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.32337293 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.32639206 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.32941120 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.33243033 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.33544947 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.33804345 </t>
+						<value>       0.25000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.34016849 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.34374230 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.34645347 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.34916465 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.35257252 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.35563446 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.35869640 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.36175834 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.36482028 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.36788222 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.37094417 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.37363511 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.40696537 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.41036272 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.41376006 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.41634116 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.41892226 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.42259364 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.42577458 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.42895552 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.43177061 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.43458569 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.43740077 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.44113873 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.44400155 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.44531418 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.44613225 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.44684935 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.44756645 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.45060264 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.45363882 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.45667500 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.46051675 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.46552281 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.46843793 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.47135305 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.47486230 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.47784911 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.48083593 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.48382274 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.48680956 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.49055899 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.49272845 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.49562624 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.49852402 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.49852402 </t>
+						<value>       0.87151445 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.50281210 </t>
+						<value>       0.87151445 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.50591393 </t>
+						<value>       0.87151445 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.50661663 </t>
+						<value>       0.86299931 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.51039279 </t>
+						<value>       0.86299931 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.51318166 </t>
+						<value>       0.86299931 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.51597053 </t>
+						<value>       0.86299931 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.51967941 </t>
+						<value>       0.86299931 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.52338828 </t>
+						<value>       0.86299931 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.52607236 </t>
+						<value>       0.86299931 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.52875645 </t>
+						<value>       0.86299931 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.53266833 </t>
+						<value>       0.86299931 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.53608219 </t>
+						<value>       0.86299931 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.53949604 </t>
+						<value>       0.86299931 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.54290990 </t>
+						<value>       0.86299931 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.54580944 </t>
+						<value>       0.86299931 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.54870898 </t>
+						<value>       0.86299931 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.55231741 </t>
+						<value>       0.86299931 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.55592583 </t>
+						<value>       0.86299931 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.55901051 </t>
+						<value>       0.86299931 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.56209520 </t>
+						<value>       0.86299931 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.56517988 </t>
+						<value>       0.86299931 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.56914352 </t>
+						<value>       0.86299931 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.57221808 </t>
+						<value>       0.86299931 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.57529263 </t>
+						<value>       0.86299931 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.57836719 </t>
+						<value>       0.86299931 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.58463767 </t>
+						<value>       0.09663630 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.58761344 </t>
+						<value>       0.09663630 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.58761344 </t>
+						<value>       0.08556021 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.59058921 </t>
+						<value>       0.08556021 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.59561333 </t>
+						<value>       0.08556021 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.59830495 </t>
+						<value>       0.08556021 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.60099657 </t>
+						<value>       0.08556021 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.60559814 </t>
+						<value>       0.08556021 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.61017059 </t>
+						<value>       0.08556021 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.61382045 </t>
+						<value>       0.08556021 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.61697962 </t>
+						<value>       0.08556021 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.62013879 </t>
+						<value>       0.08556021 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.62479002 </t>
+						<value>       0.08556021 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.62769437 </t>
+						<value>       0.08556021 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.63059871 </t>
+						<value>       0.08556021 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.63489011 </t>
+						<value>       0.08556021 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.64716920 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.67210008 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+				</x_nodes>
+				<min_nodes/>
+				<max_nodes/>
+				<kp>     100.00000000 </kp>
+				<kv>      20.00000000 </kv>
+			</ControlLinear>
+			<ControlLinear name="soleus_r">
+				<is_model_control> true </is_model_control>
+				<extrapolate> true </extrapolate>
+				<default_min>       0.02000000 </default_min>
+				<default_max>       1.00000000 </default_max>
+				<filter_on> false </filter_on>
+				<use_steps> false </use_steps>
+				<x_nodes>
+					<ControlLinearNode name="">
+						<t>       0.11700000 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.11880750 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.12114279 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.12334773 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.12555268 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.12775762 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.12919367 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.12998900 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.13078434 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.13258834 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.13358292 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.13457750 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.13828386 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.14199022 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.14779772 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.15263313 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.15746854 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.16069236 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.16391619 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.16840623 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.17152404 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.17464185 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.17843098 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.18185595 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.18528092 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.18870589 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.19213086 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.19555582 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.19898079 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.20183011 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.20467943 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.20868591 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.21177427 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.21486264 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.21795100 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.22129292 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.22463484 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.22749454 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.23035425 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.23404925 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.23688763 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.23972600 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.24256438 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.24606801 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.24957163 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.25202785 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.25448407 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.25817255 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.26147675 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.26415102 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.26682528 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.27013732 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.27344935 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.27602800 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.27860666 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.28191078 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.28521491 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.28785977 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.29050463 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.29381004 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.29711545 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.29964265 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.30216986 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.30558924 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.30900863 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.31143528 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.31386193 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.31748571 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.32050485 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.32352398 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.32654312 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.32956225 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.33258139 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.33517537 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.33776935 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.34134316 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.34405433 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.34676551 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.35017338 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.35323532 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.35629726 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.35935920 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.36242114 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.36548308 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.36854503 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.37123597 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.37392691 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.37732426 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.38072160 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.38330270 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.38588380 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.38955518 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.39273612 </t>
+						<value>       0.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.39275078 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.39556587 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.39838095 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.40119603 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.40493399 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.40779681 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.40910944 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.40992751 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.41064461 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.41136171 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.41439790 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.41743408 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.42047026 </t>
+						<value>       0.02000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.42047026 </t>
+						<value>       0.75000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.43869554 </t>
+						<value>       0.75000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.44161066 </t>
+						<value>       0.75000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.44452578 </t>
+						<value>       0.75000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.44803503 </t>
+						<value>       0.75000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.45102184 </t>
+						<value>       0.75000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.45400866 </t>
+						<value>       0.75000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.45699547 </t>
+						<value>       0.75000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.45998229 </t>
+						<value>       0.75000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.46373172 </t>
+						<value>       0.75000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.46590118 </t>
+						<value>       0.75000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.46879897 </t>
+						<value>       0.75000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.47169675 </t>
+						<value>       0.75000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.47598484 </t>
+						<value>       0.75000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.48027292 </t>
+						<value>       0.75000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.48337475 </t>
+						<value>       0.75000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.48337475 </t>
+						<value>       0.55107612 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.48715091 </t>
+						<value>       0.55107612 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.48993978 </t>
+						<value>       0.55107612 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.49272865 </t>
+						<value>       0.55107612 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.49643753 </t>
+						<value>       0.55107612 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.50014640 </t>
+						<value>       0.55107612 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.50283048 </t>
+						<value>       0.55107612 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.50551457 </t>
+						<value>       0.55107612 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.50942645 </t>
+						<value>       0.55107612 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.51284031 </t>
+						<value>       0.55107612 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.51625416 </t>
+						<value>       0.55107612 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.51966802 </t>
+						<value>       0.55107612 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.52256756 </t>
+						<value>       0.55107612 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.52546710 </t>
+						<value>       0.55107612 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.52907553 </t>
+						<value>       0.55107612 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.53268395 </t>
+						<value>       0.55107612 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.53576863 </t>
+						<value>       0.55107612 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.53885332 </t>
+						<value>       0.55107612 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.54193800 </t>
+						<value>       0.55107612 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.54590164 </t>
+						<value>       0.55107612 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.54897620 </t>
+						<value>       0.55107612 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.55205075 </t>
+						<value>       0.55107612 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.55512531 </t>
+						<value>       0.55107612 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.55939419 </t>
+						<value>       0.55107612 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.56236996 </t>
+						<value>       0.55107612 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.56534573 </t>
+						<value>       0.55107612 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.56832150 </t>
+						<value>       0.55107612 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.57445083 </t>
+						<value>       0.15086433 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.57714245 </t>
+						<value>       0.15086433 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.57983407 </t>
+						<value>       0.15086433 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.58443564 </t>
+						<value>       0.15086433 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.58900809 </t>
+						<value>       0.15086433 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.62322515 </t>
+						<value>       0.05387298 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.62638432 </t>
+						<value>       0.05387298 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.62954349 </t>
+						<value>       0.05387298 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.63419472 </t>
+						<value>       0.05387298 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.63709907 </t>
+						<value>       0.05387298 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.64000341 </t>
+						<value>       0.05387298 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.64429481 </t>
+						<value>       0.05387298 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.66993194 </t>
+						<value>       0.02715277 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.70957548 </t>
+						<value>       0.02491292 </value>
+					</ControlLinearNode>
+				</x_nodes>
+				<min_nodes/>
+				<max_nodes/>
+				<kp>     100.00000000 </kp>
+				<kv>      20.00000000 </kv>
+			</ControlLinear>
+			<ControlLinear name="tib_ant_r">
+				<is_model_control> true </is_model_control>
+				<extrapolate> true </extrapolate>
+				<default_min>       0.02000000 </default_min>
+				<default_max>       1.00000000 </default_max>
+				<filter_on> false </filter_on>
+				<use_steps> false </use_steps>
+				<x_nodes>
+					<ControlLinearNode name="">
+						<t>       0.11005169 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.11185919 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.11419448 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.11639942 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.11860437 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.12080931 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.12224536 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.12304069 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.12383603 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.12564003 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.12663461 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.12762919 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.13133555 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.13504191 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.14084941 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.14568482 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.15052023 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.15374405 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.15696788 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.16145792 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.16457573 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.16769354 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.17311778 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.17654275 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.17996772 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.18339269 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.18681766 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.19024262 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.19366759 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.19651691 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.19936623 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.20337271 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.20646107 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.20954944 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.21263780 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.21597972 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.21932164 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.22218134 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.22504105 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.22873605 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.23157443 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.23441280 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.23725118 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.24075481 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.24425843 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.24671465 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.24917087 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.25285935 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.25616355 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.25883782 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.26151208 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.26482412 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.26590113 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.26847978 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.27105844 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.27436256 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.27766669 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.28031155 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.28295641 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.28626182 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.28956723 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.29209443 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.29462164 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.29804102 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.30146041 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.30388706 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.30631371 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.30993749 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.31295663 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.31597576 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.31899490 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.32201403 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.32503317 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.32762715 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.33022113 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.33379494 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.33650611 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.33921729 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.34262516 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.35310242 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.35616436 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.35922630 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.36228824 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.36535018 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.36841213 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.37110307 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.37379401 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.37719136 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.38058870 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.38316980 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.38575090 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.38942228 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.39260322 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.39578416 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.39859925 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.40141433 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.40422941 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.40796737 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.41083019 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.41214282 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.41296089 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.41367799 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.41439509 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.41743128 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.42046746 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.42350364 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.42734539 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.43235145 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.43526657 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.43818169 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.44169094 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.44467775 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.44766457 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.45065138 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.45363820 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.45738763 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.45955709 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.46245488 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.46535266 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.46964075 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.47392883 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.47703066 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.48013250 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.48390866 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.48669753 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.48948640 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.49589425 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.49960312 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.50228720 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.50497129 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.50888317 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.51229703 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.51571088 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.51912474 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.52202428 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.52492382 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.52853225 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.53214067 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.53522535 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.53831004 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.54139472 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.54535836 </t>
+						<value>       1.00000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.55013918 </t>
+						<value>       0.10000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.58528019 </t>
+						<value>       0.10000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.58835475 </t>
+						<value>       0.10000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.59262363 </t>
+						<value>       0.10000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.59559940 </t>
+						<value>       0.10000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.59857517 </t>
+						<value>       0.10000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.60155094 </t>
+						<value>       0.10000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.60657506 </t>
+						<value>       0.10000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.60926668 </t>
+						<value>       0.10000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.61195830 </t>
+						<value>       0.10000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.61655987 </t>
+						<value>       0.10000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.62113232 </t>
+						<value>       0.10000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.62478218 </t>
+						<value>       0.10000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.62794135 </t>
+						<value>       0.10000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.63110052 </t>
+						<value>       0.10000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.63575175 </t>
+						<value>       0.10000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.63865610 </t>
+						<value>       0.10000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.64156044 </t>
+						<value>       0.10000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.64585184 </t>
+						<value>       0.10000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.64970675 </t>
+						<value>       0.10000000 </value>
+					</ControlLinearNode>
+					<ControlLinearNode name="">
+						<t>       0.69797948 </t>
+						<value>       0.10000000 </value>
+					</ControlLinearNode>
+				</x_nodes>
+				<min_nodes/>
+				<max_nodes/>
+				<kp>     100.00000000 </kp>
+				<kv>      20.00000000 </kv>
+			</ControlLinear>
+		</objects>
+		<groups/>
+		<defaults>
+			<ControlLinear name="default">
+				<is_model_control> true </is_model_control>
+				<extrapolate> true </extrapolate>
+				<default_min>  -10000.00000000 </default_min>
+				<default_max>   10000.00000000 </default_max>
+				<filter_on> false </filter_on>
+				<use_steps> false </use_steps>
+				<x_nodes/>
+				<min_nodes/>
+				<max_nodes/>
+				<kp>     100.00000000 </kp>
+				<kv>      20.00000000 </kv>
+			</ControlLinear>
+		</defaults>
+	</ControlSet>
+</OpenSimDocument>
+


### PR DESCRIPTION
Make *ground* and *ball*  `ContactGeoemetry` unique with respect to the `Model`'s  *ground* and *ball*  bodies by renaming them to *floor* and *soccer_ball*, respectively.