### PR TITLE
Install Models/Gait2354_Simbody/OutputReference IK results.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ install(DIRECTORY Pipelines/Gait2354_Simbody/
         PATTERN "forces_grf.xml" EXCLUDE
         PATTERN "subject01_Setup_Analyze_Reactions.xml" EXCLUDE
         PATTERN "subject01_Setup_AnalyzeTest.xml" EXCLUDE
-        PATTERN "subject01_walk1_ik.mot" EXCLUDE)
+        PATTERN "Pipelines/Gait2354_Simbody/subject01_walk1_ik.mot" EXCLUDE)
 
 install(FILES Models/Gait2392_Simbody/gait2392_thelen2003muscle.osim
         DESTINATION Models/Gait2392_Simbody


### PR DESCRIPTION
This PR fixes #70. The 3.3 models folder contains an IK results file in the gait2354 OutputReference folder, and this PR causes this file to be installed.