### PR TITLE
Changed Toylanding model opacity

### DIFF
--- a/Models/ToyLanding/ToyLandingModel.osim
+++ b/Models/ToyLanding/ToyLandingModel.osim
@@ -480,7 +480,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>0.1</opacity>
 								</DisplayGeometry>
 								<DisplayGeometry>
 									<!--Name of geometry file .vtp, .stl, .obj-->
@@ -496,7 +496,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 								<DisplayGeometry>
 									<!--Name of geometry file .vtp, .stl, .obj-->
@@ -512,7 +512,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 							</objects>
 							<groups />
@@ -712,7 +712,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 							</objects>
 							<groups />
@@ -878,7 +878,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 								<DisplayGeometry>
 									<!--Name of geometry file .vtp, .stl, .obj-->
@@ -894,7 +894,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 							</objects>
 							<groups />
@@ -1058,7 +1058,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 							</objects>
 							<groups />
@@ -1222,7 +1222,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 							</objects>
 							<groups />
@@ -1386,7 +1386,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 							</objects>
 							<groups />
@@ -1586,7 +1586,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 							</objects>
 							<groups />
@@ -1752,7 +1752,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 								<DisplayGeometry>
 									<!--Name of geometry file .vtp, .stl, .obj-->
@@ -1768,7 +1768,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 							</objects>
 							<groups />
@@ -1932,7 +1932,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 							</objects>
 							<groups />
@@ -2096,7 +2096,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 							</objects>
 							<groups />
@@ -2260,7 +2260,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 							</objects>
 							<groups />
@@ -2460,7 +2460,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 								<DisplayGeometry>
 									<!--Name of geometry file .vtp, .stl, .obj-->
@@ -2476,7 +2476,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 								<DisplayGeometry>
 									<!--Name of geometry file .vtp, .stl, .obj-->
@@ -2492,7 +2492,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 								<DisplayGeometry>
 									<!--Name of geometry file .vtp, .stl, .obj-->
@@ -2508,7 +2508,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 							</objects>
 							<groups />

--- a/Models/ToyLanding/ToyLandingModel.osim
+++ b/Models/ToyLanding/ToyLandingModel.osim
@@ -480,7 +480,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.1</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 								<DisplayGeometry>
 									<!--Name of geometry file .vtp, .stl, .obj-->

--- a/Models/ToyLanding/ToyLandingModel_AFO.osim
+++ b/Models/ToyLanding/ToyLandingModel_AFO.osim
@@ -480,7 +480,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 								<DisplayGeometry>
 									<!--Name of geometry file .vtp, .stl, .obj-->
@@ -496,7 +496,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 								<DisplayGeometry>
 									<!--Name of geometry file .vtp, .stl, .obj-->
@@ -512,7 +512,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 							</objects>
 							<groups />
@@ -712,7 +712,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 							</objects>
 							<groups />
@@ -878,7 +878,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 								<DisplayGeometry>
 									<!--Name of geometry file .vtp, .stl, .obj-->
@@ -894,7 +894,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 							</objects>
 							<groups />
@@ -1058,7 +1058,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 							</objects>
 							<groups />
@@ -1222,7 +1222,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 							</objects>
 							<groups />
@@ -1386,7 +1386,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 							</objects>
 							<groups />
@@ -1586,7 +1586,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 							</objects>
 							<groups />
@@ -1752,7 +1752,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 								<DisplayGeometry>
 									<!--Name of geometry file .vtp, .stl, .obj-->
@@ -1768,7 +1768,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 							</objects>
 							<groups />
@@ -1932,7 +1932,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 							</objects>
 							<groups />
@@ -2096,7 +2096,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 							</objects>
 							<groups />
@@ -2260,7 +2260,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 							</objects>
 							<groups />
@@ -2460,7 +2460,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 								<DisplayGeometry>
 									<!--Name of geometry file .vtp, .stl, .obj-->
@@ -2476,7 +2476,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 								<DisplayGeometry>
 									<!--Name of geometry file .vtp, .stl, .obj-->
@@ -2492,7 +2492,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 								<DisplayGeometry>
 									<!--Name of geometry file .vtp, .stl, .obj-->
@@ -2508,7 +2508,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 							</objects>
 							<groups />
@@ -2721,7 +2721,7 @@
           <rotational_damping>0 0 0</rotational_damping>
           <!--Damping parameters resisting relative translational velocity. (N/(m/s)-->
           <translational_damping>0.001 0.001 0.001</translational_damping>
-        </BushingForce>           
+        </BushingForce>
 				<Thelen2003Muscle name="glut_med1_r">
 					<!--Flag indicating whether the force is disabled or not. Disabled means that the force is not active in subsequent dynamics realizations.-->
 					<isDisabled>false</isDisabled>

--- a/Models/ToyLanding/ToyLandingModel_activeAFO.osim
+++ b/Models/ToyLanding/ToyLandingModel_activeAFO.osim
@@ -480,7 +480,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 								<DisplayGeometry>
 									<!--Name of geometry file .vtp, .stl, .obj-->
@@ -496,7 +496,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 								<DisplayGeometry>
 									<!--Name of geometry file .vtp, .stl, .obj-->
@@ -512,7 +512,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 							</objects>
 							<groups />
@@ -712,7 +712,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 							</objects>
 							<groups />
@@ -878,7 +878,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 								<DisplayGeometry>
 									<!--Name of geometry file .vtp, .stl, .obj-->
@@ -894,7 +894,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 							</objects>
 							<groups />
@@ -1058,7 +1058,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 							</objects>
 							<groups />
@@ -1222,7 +1222,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 							</objects>
 							<groups />
@@ -1386,7 +1386,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 							</objects>
 							<groups />
@@ -1586,7 +1586,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 							</objects>
 							<groups />
@@ -1752,7 +1752,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 								<DisplayGeometry>
 									<!--Name of geometry file .vtp, .stl, .obj-->
@@ -1768,7 +1768,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 							</objects>
 							<groups />
@@ -1932,7 +1932,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 							</objects>
 							<groups />
@@ -2096,7 +2096,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 							</objects>
 							<groups />
@@ -2260,7 +2260,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 							</objects>
 							<groups />
@@ -2460,7 +2460,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 								<DisplayGeometry>
 									<!--Name of geometry file .vtp, .stl, .obj-->
@@ -2476,7 +2476,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 								<DisplayGeometry>
 									<!--Name of geometry file .vtp, .stl, .obj-->
@@ -2492,7 +2492,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 								<DisplayGeometry>
 									<!--Name of geometry file .vtp, .stl, .obj-->
@@ -2508,7 +2508,7 @@
 									<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded-->
 									<display_preference>4</display_preference>
 									<!--Display opacity between 0.0 and 1.0-->
-									<opacity>0.2</opacity>
+									<opacity>1</opacity>
 								</DisplayGeometry>
 							</objects>
 							<groups />


### PR DESCRIPTION
Default model opacity was 0.2. This wasn't respected in 3.3, so it didn't make an issue, where in 4.0 it is. This PR changed the opacity of the bones geometry to 1. 