### PR TITLE
Rajagopal2015: Avoid PathWrap name warning.

### DIFF
--- a/Models/RajagopalModel/Rajagopal2015.osim
+++ b/Models/RajagopalModel/Rajagopal2015.osim
@@ -6470,12 +6470,12 @@
 						<!--The wrap objecs that are associated with this path-->
 						<PathWrapSet>
 							<objects>
-								<PathWrap>
+								<PathWrap name="shank">
 									<wrap_object>GasLat_at_shank_r</wrap_object>
 									<method>hybrid</method>
 									<range> -1 -1</range>
 								</PathWrap>
-								<PathWrap>
+								<PathWrap name="condyles">
 									<wrap_object>Gastroc_at_condyles_r</wrap_object>
 									<method>hybrid</method>
 									<range> -1 -1</range>
@@ -6576,12 +6576,12 @@
 						<!--The wrap objecs that are associated with this path-->
 						<PathWrapSet>
 							<objects>
-								<PathWrap>
+								<PathWrap name="shank">
 									<wrap_object>GasMed_at_shank_r</wrap_object>
 									<method>hybrid</method>
 									<range> -1 -1</range>
 								</PathWrap>
-								<PathWrap>
+								<PathWrap name="condyles">
 									<wrap_object>Gastroc_at_condyles_r</wrap_object>
 									<method>hybrid</method>
 									<range> -1 -1</range>
@@ -10662,12 +10662,12 @@
 						<!--The wrap objecs that are associated with this path-->
 						<PathWrapSet>
 							<objects>
-								<PathWrap>
+								<PathWrap name="shank">
 									<wrap_object>GasLat_at_shank_l</wrap_object>
 									<method>hybrid</method>
 									<range> -1 -1</range>
 								</PathWrap>
-								<PathWrap>
+								<PathWrap name="condyles">
 									<wrap_object>Gastroc_at_condyles_l</wrap_object>
 									<method>hybrid</method>
 									<range> -1 -1</range>
@@ -10768,12 +10768,12 @@
 						<!--The wrap objecs that are associated with this path-->
 						<PathWrapSet>
 							<objects>
-								<PathWrap>
+								<PathWrap name="shank">
 									<wrap_object>GasMed_at_shank_l</wrap_object>
 									<method>hybrid</method>
 									<range> -1 -1</range>
 								</PathWrap>
-								<PathWrap>
+								<PathWrap name="condyles">
 									<wrap_object>Gastroc_at_condyles_l</wrap_object>
 									<method>hybrid</method>
 									<range> -1 -1</range>

--- a/Pipelines/Rajagopal/outputReference/subject01_RRA_Adjusted.osim
+++ b/Pipelines/Rajagopal/outputReference/subject01_RRA_Adjusted.osim
@@ -6463,12 +6463,12 @@
 						<!--The wrap objecs that are associated with this path-->
 						<PathWrapSet>
 							<objects>
-								<PathWrap>
+								<PathWrap name="shank">
 									<wrap_object>GasLat_at_shank_r</wrap_object>
 									<method>hybrid</method>
 									<range> -1 -1</range>
 								</PathWrap>
-								<PathWrap>
+								<PathWrap name="condyles">
 									<wrap_object>Gastroc_at_condyles_r</wrap_object>
 									<method>hybrid</method>
 									<range> -1 -1</range>
@@ -6569,12 +6569,12 @@
 						<!--The wrap objecs that are associated with this path-->
 						<PathWrapSet>
 							<objects>
-								<PathWrap>
+								<PathWrap name="shank">
 									<wrap_object>GasMed_at_shank_r</wrap_object>
 									<method>hybrid</method>
 									<range> -1 -1</range>
 								</PathWrap>
-								<PathWrap>
+								<PathWrap name="condyles">
 									<wrap_object>Gastroc_at_condyles_r</wrap_object>
 									<method>hybrid</method>
 									<range> -1 -1</range>
@@ -10655,12 +10655,12 @@
 						<!--The wrap objecs that are associated with this path-->
 						<PathWrapSet>
 							<objects>
-								<PathWrap>
+								<PathWrap name="shank">
 									<wrap_object>GasLat_at_shank_l</wrap_object>
 									<method>hybrid</method>
 									<range> -1 -1</range>
 								</PathWrap>
-								<PathWrap>
+								<PathWrap name="condyles">
 									<wrap_object>Gastroc_at_condyles_l</wrap_object>
 									<method>hybrid</method>
 									<range> -1 -1</range>
@@ -10761,12 +10761,12 @@
 						<!--The wrap objecs that are associated with this path-->
 						<PathWrapSet>
 							<objects>
-								<PathWrap>
+								<PathWrap name="shank">
 									<wrap_object>GasMed_at_shank_l</wrap_object>
 									<method>hybrid</method>
 									<range> -1 -1</range>
 								</PathWrap>
-								<PathWrap>
+								<PathWrap name="condyles">
 									<wrap_object>Gastroc_at_condyles_l</wrap_object>
 									<method>hybrid</method>
 									<range> -1 -1</range>

--- a/Pipelines/Rajagopal/outputReference/subject01_registered.osim
+++ b/Pipelines/Rajagopal/outputReference/subject01_registered.osim
@@ -6463,12 +6463,12 @@
 						<!--The wrap objecs that are associated with this path-->
 						<PathWrapSet>
 							<objects>
-								<PathWrap>
+								<PathWrap name="shank">
 									<wrap_object>GasLat_at_shank_r</wrap_object>
 									<method>hybrid</method>
 									<range> -1 -1</range>
 								</PathWrap>
-								<PathWrap>
+								<PathWrap name="condyles">
 									<wrap_object>Gastroc_at_condyles_r</wrap_object>
 									<method>hybrid</method>
 									<range> -1 -1</range>
@@ -6569,12 +6569,12 @@
 						<!--The wrap objecs that are associated with this path-->
 						<PathWrapSet>
 							<objects>
-								<PathWrap>
+								<PathWrap name="shank">
 									<wrap_object>GasMed_at_shank_r</wrap_object>
 									<method>hybrid</method>
 									<range> -1 -1</range>
 								</PathWrap>
-								<PathWrap>
+								<PathWrap name="condyles">
 									<wrap_object>Gastroc_at_condyles_r</wrap_object>
 									<method>hybrid</method>
 									<range> -1 -1</range>
@@ -10655,12 +10655,12 @@
 						<!--The wrap objecs that are associated with this path-->
 						<PathWrapSet>
 							<objects>
-								<PathWrap>
+								<PathWrap name="shank">
 									<wrap_object>GasLat_at_shank_l</wrap_object>
 									<method>hybrid</method>
 									<range> -1 -1</range>
 								</PathWrap>
-								<PathWrap>
+								<PathWrap name="condyles">
 									<wrap_object>Gastroc_at_condyles_l</wrap_object>
 									<method>hybrid</method>
 									<range> -1 -1</range>
@@ -10761,12 +10761,12 @@
 						<!--The wrap objecs that are associated with this path-->
 						<PathWrapSet>
 							<objects>
-								<PathWrap>
+								<PathWrap name="shank">
 									<wrap_object>GasMed_at_shank_l</wrap_object>
 									<method>hybrid</method>
 									<range> -1 -1</range>
 								</PathWrap>
-								<PathWrap>
+								<PathWrap name="condyles">
 									<wrap_object>Gastroc_at_condyles_l</wrap_object>
 									<method>hybrid</method>
 									<range> -1 -1</range>

--- a/Pipelines/Rajagopal/outputReference/subject01_scaled.osim
+++ b/Pipelines/Rajagopal/outputReference/subject01_scaled.osim
@@ -6463,12 +6463,12 @@
 						<!--The wrap objecs that are associated with this path-->
 						<PathWrapSet>
 							<objects>
-								<PathWrap>
+								<PathWrap name="shank">
 									<wrap_object>GasLat_at_shank_r</wrap_object>
 									<method>hybrid</method>
 									<range> -1 -1</range>
 								</PathWrap>
-								<PathWrap>
+								<PathWrap name="condyles">
 									<wrap_object>Gastroc_at_condyles_r</wrap_object>
 									<method>hybrid</method>
 									<range> -1 -1</range>
@@ -6569,12 +6569,12 @@
 						<!--The wrap objecs that are associated with this path-->
 						<PathWrapSet>
 							<objects>
-								<PathWrap>
+								<PathWrap name="shank">
 									<wrap_object>GasMed_at_shank_r</wrap_object>
 									<method>hybrid</method>
 									<range> -1 -1</range>
 								</PathWrap>
-								<PathWrap>
+								<PathWrap name="condyles">
 									<wrap_object>Gastroc_at_condyles_r</wrap_object>
 									<method>hybrid</method>
 									<range> -1 -1</range>
@@ -10655,12 +10655,12 @@
 						<!--The wrap objecs that are associated with this path-->
 						<PathWrapSet>
 							<objects>
-								<PathWrap>
+								<PathWrap name="shank">
 									<wrap_object>GasLat_at_shank_l</wrap_object>
 									<method>hybrid</method>
 									<range> -1 -1</range>
 								</PathWrap>
-								<PathWrap>
+								<PathWrap name="condyles">
 									<wrap_object>Gastroc_at_condyles_l</wrap_object>
 									<method>hybrid</method>
 									<range> -1 -1</range>
@@ -10761,12 +10761,12 @@
 						<!--The wrap objecs that are associated with this path-->
 						<PathWrapSet>
 							<objects>
-								<PathWrap>
+								<PathWrap name="shank">
 									<wrap_object>GasMed_at_shank_l</wrap_object>
 									<method>hybrid</method>
 									<range> -1 -1</range>
 								</PathWrap>
-								<PathWrap>
+								<PathWrap name="condyles">
 									<wrap_object>Gastroc_at_condyles_l</wrap_object>
 									<method>hybrid</method>
 									<range> -1 -1</range>


### PR DESCRIPTION
On master, loading the Rajagopal2015.osim model generates the following warnings:

```
GeometryPath 'geometrypath' has subcomponents with duplicate name 'pathwrap'.
The duplicate is being renamed to 'pathwrap_0'.
GeometryPath 'geometrypath' has subcomponents with duplicate name 'pathwrap'.
The duplicate is being renamed to 'pathwrap_0'.
GeometryPath 'geometrypath' has subcomponents with duplicate name 'pathwrap'.
The duplicate is being renamed to 'pathwrap_0'.
GeometryPath 'geometrypath' has subcomponents with duplicate name 'pathwrap'.
The duplicate is being renamed to 'pathwrap_0'.
```

This PR gets rid of these warnings.

I updated all copies of this model that are in this repository.