### PR TITLE
Fix tag names in RRA setup file.

### DIFF
--- a/Pipelines/Gait2354_Simbody/subject01_Setup_RRA.xml
+++ b/Pipelines/Gait2354_Simbody/subject01_Setup_RRA.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <OpenSimDocument Version="20302">
-	<CMCTool name="subject01_walk1_RRA">
+	<RRATool name="subject01_walk1_RRA">
 	<!--Name of the .osim file used to construct a model.-->
 	<model_file> subject01_simbody.osim </model_file>
 	<!--Replace the model's force set with sets specified in
@@ -110,6 +110,6 @@
 			name is not specified, the model is written out to a file called
 			adjusted_model.osim.-->
 		<output_model_file> subject01_simbody_adjusted.osim </output_model_file>
-	</CMCTool>
+	</RRATool>
 </OpenSimDocument>
 


### PR DESCRIPTION
The command-line tool `opensim-cmd` runs the tool that matches the tag in the XML setup file. I found an issue where an RRA setup file had the tag `CMCTool` instead of `RRATool`, causing `opensim-cmd` to run CMC instead of RRA when provided with this setup file.

This PR fixes the tag name from `CMCTool` to `RRATool`.