### PR TITLE
for gait10dof18musc, fix IK/ID/RRA paths for final OpenSim package layout

### DIFF
--- a/Tutorials/Design_to_Reduce_Metabolic_Cost/ID/walk_Setup_ID.xml
+++ b/Tutorials/Design_to_Reduce_Metabolic_Cost/ID/walk_Setup_ID.xml
@@ -12,7 +12,7 @@
 		<!--List of forces by individual or grouping name (e.g. All, actuators, muscles, ...) to be excluded when computing model dynamics.-->
 		<forces_to_exclude> Muscles</forces_to_exclude>
 		<!--XML file (.xml) containing the external loads applied to the model as a set of ExternalForce(s).-->
-		<external_loads_file>../ExperimentalData/subject01_walk_grf.xml</external_loads_file>
+		<external_loads_file>../subject01_walk_grf.xml</external_loads_file>
 		<!--The name of the file containing coordinate data. Can be a motion (.mot) or a states (.sto) file.-->
 		<coordinates_file>../IK/subject01_walk_IK.mot</coordinates_file>
 		<!--Low-pass cut-off frequency for filtering the coordinates_file data (currently does not apply to states_file or speeds_file). A negative value results in no filtering. The default value is -1.0, so no filtering.-->

--- a/Tutorials/Design_to_Reduce_Metabolic_Cost/IK/walk_Setup_IK.xml
+++ b/Tutorials/Design_to_Reduce_Metabolic_Cost/IK/walk_Setup_IK.xml
@@ -252,7 +252,7 @@
 			<groups />
 		</IKTaskSet>
 		<!--TRC file (.trc) containing the time history of observations of marker positions.-->
-		<marker_file>../ExperimentalData/subject01_walk.trc</marker_file>
+		<marker_file>../subject01_walk.trc</marker_file>
 		<!--The name of the storage (.sto or .mot) file containing coordinate observations.Coordinate values from this file are included if there is a corresponding coordinate task. -->
 		<coordinate_file>Unassigned</coordinate_file>
 		<!--Time range over which the inverse kinematics problem is solved.-->

--- a/Tutorials/Design_to_Reduce_Metabolic_Cost/RRA/gait10dof_Kinematics_Tracking_Tasks.xml
+++ b/Tutorials/Design_to_Reduce_Metabolic_Cost/RRA/gait10dof_Kinematics_Tracking_Tasks.xml
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<OpenSimDocument Version="30000">
+	<CMC_TaskSet name="gait10dof_kinematics_tracking_tasks">
+		<objects>
+			<CMC_Joint name="pelvis_tx">
+				<!--Flag (true or false) indicating whether or not a task is enabled.-->
+				<on>true</on>
+				<!--Weight with which a task is tracked relative to other tasks. To track a task more tightly, make the weight larger.-->
+				<weight> 500 </weight>
+				<!--Flag (true or false) specifying whether a component of a task is active.  For example, tracking the trajectory of a point in space could have three components (x,y,z).  This allows each of those to be made active (true) or inactive (false).  A task for tracking a joint coordinate only has one component.-->
+				<active> true false false </active>
+				<!--Position error feedback gain (stiffness). To achieve critical damping of errors, choose kv = 2*sqrt(kp).-->
+				<kp> 100 </kp>
+				<!--Velocity error feedback gain (damping). To achieve critical damping of errors, choose kv = 2*sqrt(kp).-->
+				<kv> 20 </kv>
+				<!--Name of the coordinate to be tracked.-->
+				<coordinate>pelvis_tx</coordinate>
+			</CMC_Joint>
+      
+			<CMC_Joint name="pelvis_ty">
+				<!--Flag (true or false) indicating whether or not a task is enabled.-->
+				<on>true</on>
+				<!--Weight with which a task is tracked relative to other tasks. To track a task more tightly, make the weight larger.-->
+				<weight> 250 </weight>
+				<!--Flag (true or false) specifying whether a component of a task is active.  For example, tracking the trajectory of a point in space could have three components (x,y,z).  This allows each of those to be made active (true) or inactive (false).  A task for tracking a joint coordinate only has one component.-->
+				<active> true false false </active>
+				<!--Position error feedback gain (stiffness). To achieve critical damping of errors, choose kv = 2*sqrt(kp).-->
+				<kp> 100 </kp>
+				<!--Velocity error feedback gain (damping). To achieve critical damping of errors, choose kv = 2*sqrt(kp).-->
+				<kv> 20 </kv>
+				<!--Name of the coordinate to be tracked.-->
+				<coordinate>pelvis_ty</coordinate>
+			</CMC_Joint>
+      
+			<CMC_Joint name="pelvis_tilt">
+				<!--Flag (true or false) indicating whether or not a task is enabled.-->
+				<on>true</on>
+				<!--Weight with which a task is tracked relative to other tasks. To track a task more tightly, make the weight larger.-->
+				<weight> 700 </weight>
+				<!--Name of body frame with respect to which a tracking objective is specified. The special name 'center_of_mass' refers to the system center of mass. This property is not used for tracking joint angles.-->
+				<wrt_body>-1</wrt_body>
+				<!--Name of body frame in which the tracking objectives are expressed.  This property is not used for tracking joint angles.-->
+				<express_body>-1</express_body>
+				<!--Array of 3 flags (each true or false) specifying whether a component of a task is active.  For example, tracking the trajectory of a point in space could have three components (x,y,z).  This allows each of those to be made active (true) or inactive (false).  A task for tracking a joint coordinate only has one component.-->
+				<active> true false false</active>
+				<!--Position error feedback gain (stiffness). To achieve critical damping of errors, choose kv = 2*sqrt(kp).-->
+				<kp> 100 </kp>
+				<!--Velocity error feedback gain (damping). To achieve critical damping of errors, choose kv = 2*sqrt(kp).-->
+				<kv> 20 </kv>
+				<!--Name of the coordinate to be tracked.-->
+				<coordinate>pelvis_tilt</coordinate>
+			</CMC_Joint>
+
+			<CMC_Joint name="hip_flexion_r">
+				<!--Flag (true or false) indicating whether or not a task is enabled.-->
+				<on>true</on>
+				<!--Weight with which a task is tracked relative to other tasks. To track a task more tightly, make the weight larger.-->
+				<weight> 250</weight>
+				<!--Flag (true or false) specifying whether a component of a task is active.  For example, tracking the trajectory of a point in space could have three components (x,y,z).  This allows each of those to be made active (true) or inactive (false).  A task for tracking a joint coordinate only has one component.-->
+				<active> true false false </active>
+				<!--Position error feedback gain (stiffness). To achieve critical damping of errors, choose kv = 2*sqrt(kp).-->
+				<kp> 100 </kp>
+				<!--Velocity error feedback gain (damping). To achieve critical damping of errors, choose kv = 2*sqrt(kp).-->
+				<kv> 20 </kv>
+				<!--Name of the coordinate to be tracked.-->
+				<coordinate>hip_flexion_r</coordinate>
+			</CMC_Joint>
+      
+			<CMC_Joint name="knee_angle_r">
+				<!--Flag (true or false) indicating whether or not a task is enabled.-->
+				<on>true</on>
+				<!--Weight with which a task is tracked relative to other tasks. To track a task more tightly, make the weight larger.-->
+				<weight> 200 </weight>
+				<!--Flag (true or false) specifying whether a component of a task is active.  For example, tracking the trajectory of a point in space could have three components (x,y,z).  This allows each of those to be made active (true) or inactive (false).  A task for tracking a joint coordinate only has one component.-->
+				<active> true false false </active>
+				<!--Position error feedback gain (stiffness). To achieve critical damping of errors, choose kv = 2*sqrt(kp).-->
+				<kp> 100 </kp>
+				<!--Velocity error feedback gain (damping). To achieve critical damping of errors, choose kv = 2*sqrt(kp).-->
+				<kv> 20 </kv>
+				<!--Name of the coordinate to be tracked.-->
+				<coordinate>knee_angle_r</coordinate>
+			</CMC_Joint>
+      
+			<CMC_Joint name="ankle_angle_r">
+				<!--Flag (true or false) indicating whether or not a task is enabled.-->
+				<on>true</on>
+				<!--Weight with which a task is tracked relative to other tasks. To track a task more tightly, make the weight larger.-->
+				<weight> 400</weight>
+				<!--Flag (true or false) specifying whether a component of a task is active.  For example, tracking the trajectory of a point in space could have three components (x,y,z).  This allows each of those to be made active (true) or inactive (false).  A task for tracking a joint coordinate only has one component.-->
+				<active> true false false </active>
+				<!--Position error feedback gain (stiffness). To achieve critical damping of errors, choose kv = 2*sqrt(kp).-->
+				<kp> 100 </kp>
+				<!--Velocity error feedback gain (damping). To achieve critical damping of errors, choose kv = 2*sqrt(kp).-->
+				<kv> 20 </kv>
+				<!--Name of the coordinate to be tracked.-->
+				<coordinate>ankle_angle_r</coordinate>
+			</CMC_Joint>
+
+			<CMC_Joint name="hip_flexion_l">
+				<!--Flag (true or false) indicating whether or not a task is enabled.-->
+				<on>true</on>
+				<!--Weight with which a task is tracked relative to other tasks. To track a task more tightly, make the weight larger.-->
+				<weight> 250</weight>
+				<!--Flag (true or false) specifying whether a component of a task is active.  For example, tracking the trajectory of a point in space could have three components (x,y,z).  This allows each of those to be made active (true) or inactive (false).  A task for tracking a joint coordinate only has one component.-->
+				<active> true false false </active>
+				<!--Position error feedback gain (stiffness). To achieve critical damping of errors, choose kv = 2*sqrt(kp).-->
+				<kp> 100 </kp>
+				<!--Velocity error feedback gain (damping). To achieve critical damping of errors, choose kv = 2*sqrt(kp).-->
+				<kv> 20 </kv>
+				<!--Name of the coordinate to be tracked.-->
+				<coordinate>hip_flexion_l</coordinate>
+			</CMC_Joint>
+      
+			<CMC_Joint name="knee_angle_l">
+				<!--Flag (true or false) indicating whether or not a task is enabled.-->
+				<on>true</on>
+				<!--Weight with which a task is tracked relative to other tasks. To track a task more tightly, make the weight larger.-->
+				<weight> 200</weight>
+				<!--Flag (true or false) specifying whether a component of a task is active.  For example, tracking the trajectory of a point in space could have three components (x,y,z).  This allows each of those to be made active (true) or inactive (false).  A task for tracking a joint coordinate only has one component.-->
+				<active> true false false </active>
+				<!--Position error feedback gain (stiffness). To achieve critical damping of errors, choose kv = 2*sqrt(kp).-->
+				<kp> 100 </kp>
+				<!--Velocity error feedback gain (damping). To achieve critical damping of errors, choose kv = 2*sqrt(kp).-->
+				<kv> 20 </kv>
+				<!--Name of the coordinate to be tracked.-->
+				<coordinate>knee_angle_l</coordinate>
+			</CMC_Joint>
+      
+			<CMC_Joint name="ankle_angle_l">
+				<!--Flag (true or false) indicating whether or not a task is enabled.-->
+				<on>true</on>
+				<!--Weight with which a task is tracked relative to other tasks. To track a task more tightly, make the weight larger.-->
+				<weight> 400</weight>
+				<!--Flag (true or false) specifying whether a component of a task is active.  For example, tracking the trajectory of a point in space could have three components (x,y,z).  This allows each of those to be made active (true) or inactive (false).  A task for tracking a joint coordinate only has one component.-->
+				<active> true false false </active>
+				<!--Position error feedback gain (stiffness). To achieve critical damping of errors, choose kv = 2*sqrt(kp).-->
+				<kp> 100 </kp>
+				<!--Velocity error feedback gain (damping). To achieve critical damping of errors, choose kv = 2*sqrt(kp).-->
+				<kv> 20 </kv>
+				<!--Name of the coordinate to be tracked.-->
+				<coordinate>ankle_angle_l</coordinate>
+			</CMC_Joint>
+
+			<CMC_Joint name="lumbar_extension">
+				<!--Flag (true or false) indicating whether or not a task is enabled.-->
+				<on>true</on>
+				<!--Weight with which a task is tracked relative to other tasks. To track a task more tightly, make the weight larger.-->
+				<weight> 500 </weight>
+				<!--Flag (true or false) specifying whether a component of a task is active.  For example, tracking the trajectory of a point in space could have three components (x,y,z).  This allows each of those to be made active (true) or inactive (false).  A task for tracking a joint coordinate only has one component.-->
+				<active> true false false </active>
+				<!--Position error feedback gain (stiffness). To achieve critical damping of errors, choose kv = 2*sqrt(kp).-->
+				<kp> 100 </kp>
+				<!--Velocity error feedback gain (damping). To achieve critical damping of errors, choose kv = 2*sqrt(kp).-->
+				<kv> 20 </kv>
+				<!--Name of the coordinate to be tracked.-->
+				<coordinate>lumbar_extension</coordinate>
+			</CMC_Joint>
+		</objects>
+		<groups />
+	</CMC_TaskSet>
+</OpenSimDocument>

--- a/Tutorials/Design_to_Reduce_Metabolic_Cost/RRA/gait10dof_Reserve_Actuators.xml
+++ b/Tutorials/Design_to_Reduce_Metabolic_Cost/RRA/gait10dof_Reserve_Actuators.xml
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<OpenSimDocument Version="30000">
+	<ForceSet name="gait10dof_Reserve_Actuators">
+		<objects>
+        <!-- Actuators on the base segement are called Residual actuators 
+             whose forces account for the errors in the model, its kinematic
+             that do not balance with experimental ground reaction forces -->
+			<PointActuator name="FX">
+				<!--Flag indicating whether the force is disabled or not. Disabled means that the force is not active in subsequent dynamics realizations.-->
+				<isDisabled>false</isDisabled>
+				<!--Minimum allowed value for control signal. Used primarily when solving for control values.-->
+				<min_control>-Inf</min_control>
+				<!--Maximum allowed value for control signal. Used primarily when solving for control values.-->
+				<max_control>Inf</max_control>
+				<!--Name of Body to which this actuator is applied.-->
+				<body>pelvis</body>
+				<!--Location of application point; in body frame unless point_is_global=true-->
+				<point>-0.034 0.0 0</point>
+				<!--Interpret point in Ground frame if true; otherwise, body frame.-->
+				<point_is_global>false</point_is_global>
+				<!--Force application direction; in body frame unless force_is_global=true.-->
+				<direction>1 0 0</direction>
+				<!--Interpret direction in Ground frame if true; otherwise, body frame.-->
+				<force_is_global>true</force_is_global>
+				<!--The maximum force produced by this actuator when fully activated.-->
+				<optimal_force>1</optimal_force>
+			</PointActuator>
+			<PointActuator name="FY">
+				<!--Flag indicating whether the force is disabled or not. Disabled means that the force is not active in subsequent dynamics realizations.-->
+				<isDisabled>false</isDisabled>
+				<!--Minimum allowed value for control signal. Used primarily when solving for control values.-->
+				<min_control>-Inf</min_control>
+				<!--Maximum allowed value for control signal. Used primarily when solving for control values.-->
+				<max_control>Inf</max_control>
+				<!--Name of Body to which this actuator is applied.-->
+				<body>pelvis</body>
+				<!--Location of application point; in body frame unless point_is_global=true-->
+				<point>-0.034 0.0 0</point>
+				<!--Interpret point in Ground frame if true; otherwise, body frame.-->
+				<point_is_global>false</point_is_global>
+				<!--Force application direction; in body frame unless force_is_global=true.-->
+				<direction>0 1 0</direction>
+				<!--Interpret direction in Ground frame if true; otherwise, body frame.-->
+				<force_is_global>true</force_is_global>
+				<!--The maximum force produced by this actuator when fully activated.-->
+				<optimal_force>2</optimal_force>
+			</PointActuator>
+			<TorqueActuator name="MZ">
+				<!--Flag indicating whether the force is disabled or not. Disabled means that the force is not active in subsequent dynamics realizations.-->
+				<isDisabled>false</isDisabled>
+				<!--Minimum allowed value for control signal. Used primarily when solving for control values.-->
+				<min_control>-Inf</min_control>
+				<!--Maximum allowed value for control signal. Used primarily when solving for control values.-->
+				<max_control>Inf</max_control>
+				<!--Name of Body to which the torque actuator is applied.-->
+				<bodyA>pelvis</bodyA>
+				<!--Name of Body to which the equal and opposite torque is applied.-->
+				<bodyB>ground</bodyB>
+				<!--Interpret axis in Ground frame if true; otherwise, body A's frame.-->
+				<torque_is_global>true</torque_is_global>
+				<!--Fixed direction about which torque is applied, in Ground or body A frame depending on 'torque_is_global' property.-->
+				<axis>0 0 1</axis>
+				<!--The maximum torque produced by this actuator when fully activated.-->
+				<optimal_force>1</optimal_force>
+			</TorqueActuator>
+
+      <!-- Actuators on the Coordinates are called Reserve actuators 
+           and are used the drive the model when the model excludes its muscles (i.e. RRA)
+           or when muscles are insufficient to track desired kinematics (CMC) -->
+			<CoordinateActuator name="hip_flexion_r_reserve">
+				<!--Flag indicating whether the force is disabled or not. Disabled means that the force is not active in subsequent dynamics realizations.-->
+				<isDisabled>false</isDisabled>
+				<!--Minimum allowed value for control signal. Used primarily when solving for control values.-->
+				<min_control>-Inf</min_control>
+				<!--Maximum allowed value for control signal. Used primarily when solving for control values.-->
+				<max_control>Inf</max_control>
+				<!--Name of the generalized coordinate to which the actuator applies.-->
+				<coordinate>hip_flexion_r</coordinate>
+				<!--The maximum generalized force produced by this actuator.-->
+				<optimal_force>1</optimal_force>
+			</CoordinateActuator>
+			<CoordinateActuator name="knee_angle_r_reserve">
+				<!--Flag indicating whether the force is disabled or not. Disabled means that the force is not active in subsequent dynamics realizations.-->
+				<isDisabled>false</isDisabled>
+				<!--Minimum allowed value for control signal. Used primarily when solving for control values.-->
+				<min_control>-Inf</min_control>
+				<!--Maximum allowed value for control signal. Used primarily when solving for control values.-->
+				<max_control>Inf</max_control>
+				<!--Name of the generalized coordinate to which the actuator applies.-->
+				<coordinate>knee_angle_r</coordinate>
+				<!--The maximum generalized force produced by this actuator.-->
+				<optimal_force>1</optimal_force>
+			</CoordinateActuator>
+			<CoordinateActuator name="ankle_angle_r_reserve">
+				<!--Flag indicating whether the force is disabled or not. Disabled means that the force is not active in subsequent dynamics realizations.-->
+				<isDisabled>false</isDisabled>
+				<!--Minimum allowed value for control signal. Used primarily when solving for control values.-->
+				<min_control>-Inf</min_control>
+				<!--Maximum allowed value for control signal. Used primarily when solving for control values.-->
+				<max_control>Inf</max_control>
+				<!--Name of the generalized coordinate to which the actuator applies.-->
+				<coordinate>ankle_angle_r</coordinate>
+				<!--The maximum generalized force produced by this actuator.-->
+				<optimal_force>1</optimal_force>
+			</CoordinateActuator>
+			<CoordinateActuator name="hip_flexion_l_reserve">
+				<!--Flag indicating whether the force is disabled or not. Disabled means that the force is not active in subsequent dynamics realizations.-->
+				<isDisabled>false</isDisabled>
+				<!--Minimum allowed value for control signal. Used primarily when solving for control values.-->
+				<min_control>-Inf</min_control>
+				<!--Maximum allowed value for control signal. Used primarily when solving for control values.-->
+				<max_control>Inf</max_control>
+				<!--Name of the generalized coordinate to which the actuator applies.-->
+				<coordinate>hip_flexion_l</coordinate>
+				<!--The maximum generalized force produced by this actuator.-->
+				<optimal_force>1</optimal_force>
+			</CoordinateActuator>
+			<CoordinateActuator name="knee_angle_l_reserve">
+				<!--Flag indicating whether the force is disabled or not. Disabled means that the force is not active in subsequent dynamics realizations.-->
+				<isDisabled>false</isDisabled>
+				<!--Minimum allowed value for control signal. Used primarily when solving for control values.-->
+				<min_control>-Inf</min_control>
+				<!--Maximum allowed value for control signal. Used primarily when solving for control values.-->
+				<max_control>Inf</max_control>
+				<!--Name of the generalized coordinate to which the actuator applies.-->
+				<coordinate>knee_angle_l</coordinate>
+				<!--The maximum generalized force produced by this actuator.-->
+				<optimal_force>1</optimal_force>
+			</CoordinateActuator>
+			<CoordinateActuator name="ankle_angle_l_reserve">
+				<!--Flag indicating whether the force is disabled or not. Disabled means that the force is not active in subsequent dynamics realizations.-->
+				<isDisabled>false</isDisabled>
+				<!--Minimum allowed value for control signal. Used primarily when solving for control values.-->
+				<min_control>-Inf</min_control>
+				<!--Maximum allowed value for control signal. Used primarily when solving for control values.-->
+				<max_control>Inf</max_control>
+				<!--Name of the generalized coordinate to which the actuator applies.-->
+				<coordinate>ankle_angle_l</coordinate>
+				<!--The maximum generalized force produced by this actuator.-->
+				<optimal_force>1</optimal_force>
+			</CoordinateActuator>
+			<CoordinateActuator name="lumbar_extension_reserve">
+				<!--Flag indicating whether the force is disabled or not. Disabled means that the force is not active in subsequent dynamics realizations.-->
+				<isDisabled>false</isDisabled>
+				<!--Minimum allowed value for control signal. Used primarily when solving for control values.-->
+				<min_control>-Inf</min_control>
+				<!--Maximum allowed value for control signal. Used primarily when solving for control values.-->
+				<max_control>Inf</max_control>
+				<!--Name of the generalized coordinate to which the actuator applies.-->
+				<coordinate>lumbar_extension</coordinate>
+				<!--The maximum generalized force produced by this actuator.-->
+				<optimal_force>1</optimal_force>
+			</CoordinateActuator>
+		</objects>
+		<groups />
+	</ForceSet>
+</OpenSimDocument>

--- a/Tutorials/Design_to_Reduce_Metabolic_Cost/RRA/walk_Setup_RRA.xml
+++ b/Tutorials/Design_to_Reduce_Metabolic_Cost/RRA/walk_Setup_RRA.xml
@@ -36,13 +36,13 @@
 			<groups />
 		</ControllerSet>
 		<!--XML file (.xml) containing the forces applied to the model as ExternalLoads.-->
-		<external_loads_file>../ExperimentalData/subject01_walk_grf.xml</external_loads_file>
+		<external_loads_file>../subject01_walk_grf.xml</external_loads_file>
 		<!--Motion (.mot) or storage (.sto) file containing the desired point trajectories.-->
 		<desired_points_file />
 		<!--Motion (.mot) or storage (.sto) file containing the desired kinematic trajectories.-->
 		<desired_kinematics_file>../IK/subject01_walk_IK.mot</desired_kinematics_file>
 		<!--File containing the tracking tasks. Which coordinates are tracked and with what weights are specified here.-->
-		<task_set_file>../gait10dof_Kinematics_Tracking_Tasks.xml</task_set_file>
+		<task_set_file>gait10dof_Kinematics_Tracking_Tasks.xml</task_set_file>
 		<!--DEPRECATED File containing the constraints on the controls.-->
 		<constraints_file />
 		<!--Low-pass cut-off frequency for filtering the desired kinematics. A negative value results in no filtering. The default value is -1.0, so no filtering.-->


### PR DESCRIPTION
Background: I doubt the IK, ID, and RRA files are used much because the corresponding tutorial only uses CMC. I was testing ID with these files, which is how I ran into these discrepancies. Short list of changes:

- IK: change marker_file to be consistent with final layout (layout based on what I can tell what happens [here](https://github.com/opensim-org/opensim-models/blob/3645ffbb01ea46705836838c9d1e6e5b74eed37c/CMakeLists.txt#L33))
- ID: change external_loads file to be consistent with final layout
- RRA: fix paths and add missing files to run in final layout

I know that this now makes the paths seem wrong if you were to run them in this Tutorials folder, but this is now consistent with CMC (where the CMC files shouldn't run as is in these Tutorials folders, but does run in the final layout shipped with OpenSim). We may want to revisit this later, but I think this is the most direct, smallest change. We could also just fix these files and the corresponding [CMakeLists.txt that installs these files](https://github.com/opensim-org/opensim-models/blob/3645ffbb01ea46705836838c9d1e6e5b74eed37c/CMakeLists.txt#L33) now too. 

@aymanhab let me know what you think