### PR TITLE
Triangle Inequality Fix

### DIFF
--- a/Models/Hamner/FullBodyModel_Hamner2010_v2_0.osim
+++ b/Models/Hamner/FullBodyModel_Hamner2010_v2_0.osim
@@ -358,7 +358,7 @@
 					<!--The location (Vec3) of the mass center in the body frame.-->
 					<mass_center>0.034599999999999999 0.0060000000000000001 -0.017500000000000002</mass_center>
 					<!--The elements of the inertia tensor (Vec6) as [Ixx Iyy Izz Ixy Ixz Iyz] measured about the mass_center and not the body origin.-->
-					<inertia>0.0001 0.00020000000000000001 0.001 0 0 0</inertia>
+					<inertia>0.0001 0.00110000000000000001 0.001 0 0 0</inertia>
 				</Body>
 				<Body name="femur_l">
 					<!--The geometry used to display the axes of this Frame.-->
@@ -521,7 +521,7 @@
 					<!--The location (Vec3) of the mass center in the body frame.-->
 					<mass_center>0.034599999999999999 0.0060000000000000001 0.017500000000000002</mass_center>
 					<!--The elements of the inertia tensor (Vec6) as [Ixx Iyy Izz Ixy Ixz Iyz] measured about the mass_center and not the body origin.-->
-					<inertia>0.0001 0.00020000000000000001 0.001 0 0 0</inertia>
+					<inertia>0.0001 0.00110000000000000001 0.001 0 0 0</inertia>
 				</Body>
 				<Body name="torso">
 					<!--The geometry used to display the axes of this Frame.-->

--- a/Models/Rajagopal/Rajagopal2016.osim
+++ b/Models/Rajagopal/Rajagopal2016.osim
@@ -1174,7 +1174,7 @@
 					<!--The location (Vec3) of the mass center in the body frame.-->
 					<mass_center>0.034599999999999999 0.0060000000000000001 -0.017500000000000002</mass_center>
 					<!--The elements of the inertia tensor (Vec6) as [Ixx Iyy Izz Ixy Ixz Iyz] measured about the mass_center and not the body origin.-->
-					<inertia>0.0001 0.00020000000000000001 0.001 0 0 0</inertia>
+					<inertia>0.0001 0.00110000000000000001 0.001 0 0 0</inertia>
 				</Body>
 				<Body name="femur_l">
 					<!--The geometry used to display the axes of this Frame.-->
@@ -1839,7 +1839,7 @@
 					<!--The location (Vec3) of the mass center in the body frame.-->
 					<mass_center>0.034599999999999999 0.0060000000000000001 0.017500000000000002</mass_center>
 					<!--The elements of the inertia tensor (Vec6) as [Ixx Iyy Izz Ixy Ixz Iyz] measured about the mass_center and not the body origin.-->
-					<inertia>0.0001 0.00020000000000000001 0.001 0 0 0</inertia>
+					<inertia>0.0001 0.00110000000000000001 0.001 0 0 0</inertia>
 				</Body>
 				<Body name="torso">
 					<!--The geometry used to display the axes of this Frame.-->

--- a/Models/Rajagopal/RajagopalLaiUhlrich2023.osim
+++ b/Models/Rajagopal/RajagopalLaiUhlrich2023.osim
@@ -1108,7 +1108,7 @@
 					<!--The location (Vec3) of the mass center in the body frame.-->
 					<mass_center>0.034599999999999999 0.0060000000000000001 -0.017500000000000002</mass_center>
 					<!--The elements of the inertia tensor (Vec6) as [Ixx Iyy Izz Ixy Ixz Iyz] measured about the mass_center and not the body origin.-->
-					<inertia>0.0001 0.00020000000000000001 0.001 0 0 0</inertia>
+					<inertia>0.0001 0.00110000000000000001 0.001 0 0 0</inertia>
 				</Body>
 				<Body name="femur_l">
 					<!--The geometry used to display the axes of this Frame.-->
@@ -1834,7 +1834,7 @@
 					<!--The location (Vec3) of the mass center in the body frame.-->
 					<mass_center>0.034599999999999999 0.0060000000000000001 0.017500000000000002</mass_center>
 					<!--The elements of the inertia tensor (Vec6) as [Ixx Iyy Izz Ixy Ixz Iyz] measured about the mass_center and not the body origin.-->
-					<inertia>0.0001 0.00020000000000000001 0.001 0 0 0</inertia>
+					<inertia>0.0001 0.00110000000000000001 0.001 0 0 0</inertia>
 				</Body>
 				<Body name="torso">
 					<!--The geometry used to display the axes of this Frame.-->

--- a/Pipelines/Gait2392_Simbody/OutputReference/subject01_simbody.osim
+++ b/Pipelines/Gait2392_Simbody/OutputReference/subject01_simbody.osim
@@ -318,7 +318,7 @@
 					<!--The location (Vec3) of the mass center in the body frame.-->
 					<mass_center>0.03553713 0.0061625100000000004 -0.017973980000000001</mass_center>
 					<!--The elements of the inertia tensor (Vec6) as [Ixx Iyy Izz Ixy Ixz Iyz] measured about the mass_center and not the body origin.-->
-					<inertia>0.00010189 0.00020378 0.00101891 0 0 0</inertia>
+					<inertia>0.00010189 0.0011208000000000001 0.00101891 0 0 0</inertia>
 				</Body>
 				<Body name="femur_l">
 					<!--The geometry used to display the axes of this Frame.-->
@@ -523,7 +523,7 @@
 					<!--The location (Vec3) of the mass center in the body frame.-->
 					<mass_center>0.03553713 0.0061625100000000004 0.017973980000000001</mass_center>
 					<!--The elements of the inertia tensor (Vec6) as [Ixx Iyy Izz Ixy Ixz Iyz] measured about the mass_center and not the body origin.-->
-					<inertia>0.00010189 0.00020378 0.00101891 0 0 0</inertia>
+					<inertia>0.00010189 0.0011208000000000001 0.00101891 0 0 0</inertia>
 				</Body>
 				<Body name="torso">
 					<!--The geometry used to display the axes of this Frame.-->

--- a/Pipelines/Gait2392_Simbody/OutputReference/subject01_simbody_adjusted.osim
+++ b/Pipelines/Gait2392_Simbody/OutputReference/subject01_simbody_adjusted.osim
@@ -318,7 +318,7 @@
 					<!--The location (Vec3) of the mass center in the body frame.-->
 					<mass_center>0.03553713 0.0061625100000000004 -0.017973980000000001</mass_center>
 					<!--The elements of the inertia tensor (Vec6) as [Ixx Iyy Izz Ixy Ixz Iyz] measured about the mass_center and not the body origin.-->
-					<inertia>0.00010189 0.00020378 0.00101891 0 0 0</inertia>
+					<inertia>0.00010189 0.0011208000000000001 0.00101891 0 0 0</inertia>
 				</Body>
 				<Body name="femur_l">
 					<!--The geometry used to display the axes of this Frame.-->
@@ -523,7 +523,7 @@
 					<!--The location (Vec3) of the mass center in the body frame.-->
 					<mass_center>0.03553713 0.0061625100000000004 0.017973980000000001</mass_center>
 					<!--The elements of the inertia tensor (Vec6) as [Ixx Iyy Izz Ixy Ixz Iyz] measured about the mass_center and not the body origin.-->
-					<inertia>0.00010189 0.00020378 0.00101891 0 0 0</inertia>
+					<inertia>0.00010189 0.0011208000000000001 0.00101891 0 0 0</inertia>
 				</Body>
 				<Body name="torso">
 					<!--The geometry used to display the axes of this Frame.-->

--- a/Pipelines/Hamner/FullBodyModel_Hamner2010_v2_0.osim
+++ b/Pipelines/Hamner/FullBodyModel_Hamner2010_v2_0.osim
@@ -358,7 +358,7 @@
 					<!--The location (Vec3) of the mass center in the body frame.-->
 					<mass_center>0.034599999999999999 0.0060000000000000001 -0.017500000000000002</mass_center>
 					<!--The elements of the inertia tensor (Vec6) as [Ixx Iyy Izz Ixy Ixz Iyz] measured about the mass_center and not the body origin.-->
-					<inertia>0.0001 0.00020000000000000001 0.001 0 0 0</inertia>
+					<inertia>0.0001 0.00110000000000000001 0.001 0 0 0</inertia>
 				</Body>
 				<Body name="femur_l">
 					<!--The geometry used to display the axes of this Frame.-->
@@ -521,7 +521,7 @@
 					<!--The location (Vec3) of the mass center in the body frame.-->
 					<mass_center>0.034599999999999999 0.0060000000000000001 0.017500000000000002</mass_center>
 					<!--The elements of the inertia tensor (Vec6) as [Ixx Iyy Izz Ixy Ixz Iyz] measured about the mass_center and not the body origin.-->
-					<inertia>0.0001 0.00020000000000000001 0.001 0 0 0</inertia>
+					<inertia>0.0001 0.00110000000000000001 0.001 0 0 0</inertia>
 				</Body>
 				<Body name="torso">
 					<!--The geometry used to display the axes of this Frame.-->

--- a/Pipelines/Hamner/outputReference/subject02_RRA_Adjusted.osim
+++ b/Pipelines/Hamner/outputReference/subject02_RRA_Adjusted.osim
@@ -302,7 +302,7 @@
 					<!--The location (Vec3) of the mass center in the body frame.-->
 					<mass_center>0.038059999999999997 0.0066 -0.01925</mass_center>
 					<!--The elements of the inertia tensor (Vec6) as [Ixx Iyy Izz Ixy Ixz Iyz] measured about the mass_center and not the body origin.-->
-					<inertia>0.000106086 0.000212172 0.0010608600000000001 0 0 0</inertia>
+					<inertia>0.000106086 0.001166946 0.0010608600000000001 0 0 0</inertia>
 				</Body>
 				<Body name="femur_l">
 					<!--The geometry used to display the axes of this Frame.-->
@@ -507,7 +507,7 @@
 					<!--The location (Vec3) of the mass center in the body frame.-->
 					<mass_center>0.038059999999999997 0.0066 0.01925</mass_center>
 					<!--The elements of the inertia tensor (Vec6) as [Ixx Iyy Izz Ixy Ixz Iyz] measured about the mass_center and not the body origin.-->
-					<inertia>0.000106086 0.000212172 0.0010608600000000001 0 0 0</inertia>
+					<inertia>0.000106086 0.001166946 0.0010608600000000001 0 0 0</inertia>
 				</Body>
 				<Body name="torso">
 					<!--The geometry used to display the axes of this Frame.-->

--- a/Pipelines/Hamner/outputReference/subject02_registered.osim
+++ b/Pipelines/Hamner/outputReference/subject02_registered.osim
@@ -302,7 +302,7 @@
 					<!--The location (Vec3) of the mass center in the body frame.-->
 					<mass_center>0.038059999999999997 0.0066 -0.01925</mass_center>
 					<!--The elements of the inertia tensor (Vec6) as [Ixx Iyy Izz Ixy Ixz Iyz] measured about the mass_center and not the body origin.-->
-					<inertia>0.000106086 0.000212172 0.0010608600000000001 0 0 0</inertia>
+					<inertia>0.000106086 0.001166946 0.0010608600000000001 0 0 0</inertia>
 				</Body>
 				<Body name="femur_l">
 					<!--The geometry used to display the axes of this Frame.-->
@@ -507,7 +507,7 @@
 					<!--The location (Vec3) of the mass center in the body frame.-->
 					<mass_center>0.038059999999999997 0.0066 0.01925</mass_center>
 					<!--The elements of the inertia tensor (Vec6) as [Ixx Iyy Izz Ixy Ixz Iyz] measured about the mass_center and not the body origin.-->
-					<inertia>0.000106086 0.000212172 0.0010608600000000001 0 0 0</inertia>
+					<inertia>0.000106086 0.001166946 0.0010608600000000001 0 0 0</inertia>
 				</Body>
 				<Body name="torso">
 					<!--The geometry used to display the axes of this Frame.-->

--- a/Pipelines/Hamner/outputReference/subject02_scaled.osim
+++ b/Pipelines/Hamner/outputReference/subject02_scaled.osim
@@ -302,7 +302,7 @@
 					<!--The location (Vec3) of the mass center in the body frame.-->
 					<mass_center>0.038059999999999997 0.0066 -0.01925</mass_center>
 					<!--The elements of the inertia tensor (Vec6) as [Ixx Iyy Izz Ixy Ixz Iyz] measured about the mass_center and not the body origin.-->
-					<inertia>0.000106086 0.000212172 0.0010608600000000001 0 0 0</inertia>
+					<inertia>0.000106086 0.001166946 0.0010608600000000001 0 0 0</inertia>
 				</Body>
 				<Body name="femur_l">
 					<!--The geometry used to display the axes of this Frame.-->
@@ -507,7 +507,7 @@
 					<!--The location (Vec3) of the mass center in the body frame.-->
 					<mass_center>0.038059999999999997 0.0066 0.01925</mass_center>
 					<!--The elements of the inertia tensor (Vec6) as [Ixx Iyy Izz Ixy Ixz Iyz] measured about the mass_center and not the body origin.-->
-					<inertia>0.000106086 0.000212172 0.0010608600000000001 0 0 0</inertia>
+					<inertia>0.000106086 0.001166946 0.0010608600000000001 0 0 0</inertia>
 				</Body>
 				<Body name="torso">
 					<!--The geometry used to display the axes of this Frame.-->


### PR DESCRIPTION
Resolves [this issue](https://github.com/opensim-org/opensim-core/issues/3941#issuecomment-2504573351)

I created [this python script](https://github.com/gateway240/opensim-core-examples/blob/main/TriangleInequalityRepair/repair-triangle-inequality.py) which identifies in a `.osim` model which inertial constraints will fail the triangle inequality and calculates the minimum change in one element required to fix them. I have tested with the models before and after and in my testing the models do not work prior to the repair and do work after.